### PR TITLE
Reference internal packages instead of deprecated external packages.

### DIFF
--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -6,12 +6,9 @@ import {
 
 import {
   NotebookModel, NotebookWidget,
-  NBData, populateNotebookModel
-} from '../../lib/index';
-
-import {
+  NBData, populateNotebookModel,
   isMarkdownCell
-} from 'jupyter-js-cells';
+} from '../../lib/index';
 
 import {
   IKeyBinding, KeymapManager, keystrokeForKeydownEvent

--- a/package.json
+++ b/package.json
@@ -7,10 +7,7 @@
   "dependencies": {
     "codemirror": "^5.11.0",
     "diff-match-patch": "^1.0.0",
-    "jupyter-js-cells": "^0.2.6",
     "jupyter-js-editor": "^0.1.10",
-    "jupyter-js-input-area": "^0.0.6",
-    "jupyter-js-output-area": "^0.3.1",
     "marked": "^0.3.5",
     "phosphor-disposable": "^1.0.5",
     "phosphor-observablelist": "^1.0.0-beta",

--- a/src/cells/model.ts
+++ b/src/cells/model.ts
@@ -5,10 +5,10 @@
 
 import {
   IInputAreaModel
-} from 'jupyter-js-input-area';
+} from '../input-area';
 import {
   IOutputAreaModel
-} from 'jupyter-js-output-area';
+} from '../output-area';
 
 import {
   IObservableList

--- a/src/cells/widget.ts
+++ b/src/cells/widget.ts
@@ -20,11 +20,11 @@ import {
 
 import {
     InputAreaWidget, IInputAreaModel
-} from 'jupyter-js-input-area';
+} from '../input-area';
 
 import {
     OutputAreaWidget, IOutputAreaModel
-} from 'jupyter-js-output-area';
+} from '../output-area';
 
 import * as marked from 'marked';
 

--- a/src/notebook/model.ts
+++ b/src/notebook/model.ts
@@ -3,7 +3,7 @@ import {
   ICodeCellModel, CodeCellModel,
   IMarkdownCellModel, MarkdownCellModel,
   IRawCellModel
-} from 'jupyter-js-cells';
+} from '../cells';
 
 import {
   IObservableList, ObservableList, ListChangeType
@@ -23,14 +23,14 @@ import {
 
 import {
   InputAreaModel
-} from 'jupyter-js-input-area';
+} from '../input-area';
 
 import {
   OutputAreaModel,
   DisplayDataModel, ExecuteResultModel,
   ExecuteErrorModel, StreamModel,
   StreamName
-} from 'jupyter-js-output-area';
+} from '../output-area';
 
 
 /**

--- a/src/notebook/serialize.ts
+++ b/src/notebook/serialize.ts
@@ -9,11 +9,11 @@ import {
 import {
   ICellModel,
   CodeCellModel, MarkdownCellModel
-} from 'jupyter-js-cells';
+} from '../cells';
 
 import {
   InputAreaModel
-} from 'jupyter-js-input-area';
+} from '../input-area';
 
 import {
   EditorModel
@@ -24,7 +24,7 @@ import {
   DisplayDataModel, ExecuteResultModel,
   ExecuteErrorModel, StreamModel,
   StreamName, OutputType, OutputModel
-} from 'jupyter-js-output-area';
+} from '../output-area';
 
 import {
   NBData, MarkdownCell, CodeCell, 

--- a/src/notebook/widget.ts
+++ b/src/notebook/widget.ts
@@ -26,11 +26,11 @@ import {
   ICellModel, CellType,
     CodeCellWidget, MarkdownCellWidget,
     CodeCellModel, MarkdownCellModel, isMarkdownCell
-} from 'jupyter-js-cells';
+} from '../cells';
 
 import {
     OutputAreaWidget, IOutputAreaModel
-} from 'jupyter-js-output-area';
+} from '../output-area';
 
 import {
   DisposableDelegate, IDisposable


### PR DESCRIPTION
These are leftover changes from the big squeeze.
