### PR TITLE
Remove duplicate exports

### DIFF
--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -7,7 +7,7 @@ import {
 import {
   NotebookModel, NotebookWidget,
   NBData, populateNotebookModel,
-  isMarkdownCell
+  isMarkdownCellModel
 } from '../../lib/index';
 
 import {
@@ -39,10 +39,10 @@ function bindings(nbModel: NotebookModel) {
         handler: args => {
         if (nbModel.selectedCellIndex !== void 0) {
           let cell = nbModel.cells.get(nbModel.selectedCellIndex);
-          if (isMarkdownCell(cell) && !cell.rendered) {
+          if (isMarkdownCellModel(cell) && !cell.rendered) {
             cell.rendered = true;
           }
-        }          
+        }
         }
       })
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-js-notebook",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Notebook widget for Jupyter",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/cells/model.ts
+++ b/src/cells/model.ts
@@ -198,7 +198,7 @@ class BaseCellModel implements IBaseCellModel {
   get input() {
     return BaseCellModel.inputProperty.get(this);
   }
-  
+
   /**
    * Set the input area model.
    *
@@ -224,7 +224,7 @@ class CodeCellModel extends BaseCellModel implements ICodeCellModel {
 
   /**
   * A property descriptor holding the output area model.
-  * 
+  *
   * TODO: Do we need this execute signal?
   * **See also:** [[output]]
   */
@@ -240,10 +240,10 @@ class CodeCellModel extends BaseCellModel implements ICodeCellModel {
    * #### Notes
    * This is a pure delegate to the [[outputProperty]].
    */
-  get output() { 
-      return CodeCellModel.outputProperty.get(this); 
+  get output() {
+      return CodeCellModel.outputProperty.get(this);
   }
-  
+
   /**
    * Set the output area model.
    *
@@ -253,7 +253,7 @@ class CodeCellModel extends BaseCellModel implements ICodeCellModel {
   set output(value: IOutputAreaModel) {
       CodeCellModel.outputProperty.set(this, value);
   }
-  
+
   type: CellType = CellType.Code;
 }
 
@@ -293,15 +293,15 @@ class MarkdownCellModel extends BaseCellModel implements IMarkdownCellModel {
   set rendered(value: boolean) {
     MarkdownCellModel.renderedProperty.set(this, value);
   }
-  
+
   type: CellType = CellType.Markdown;
 }
 
 /**
-  * A type guard for testing if a cell is a markdown cell.
+  * A type guard for testing if a cell model is a markdown cell.
   */
 export
-function isMarkdownCell(m: ICellModel): m is IMarkdownCellModel {
+function isMarkdownCellModel(m: ICellModel): m is IMarkdownCellModel {
   return (m.type === CellType.Markdown);
 }
 
@@ -309,7 +309,7 @@ function isMarkdownCell(m: ICellModel): m is IMarkdownCellModel {
   * A type guard for testing if a cell is a code cell.
   */
 export
-function isCodeCell(m: ICellModel): m is ICodeCellModel {
+function isCodeCellModel(m: ICellModel): m is ICodeCellModel {
   return (m.type === CellType.Code);
 }
 
@@ -317,6 +317,6 @@ function isCodeCell(m: ICellModel): m is ICodeCellModel {
   * A type guard for testing if a cell is a raw cell.
   */
 export
-function isRawCell(m: ICellModel): m is IRawCellModel {
+function isRawCellModel(m: ICellModel): m is IRawCellModel {
   return (m.type === CellType.Raw);
 }

--- a/src/notebook/nbformat.ts
+++ b/src/notebook/nbformat.ts
@@ -1,18 +1,12 @@
 // Notebook format interfaces
 
+import {
+    MimeBundle
+} from '../output-area';
+
 // In the notebook format *disk* representation, this would be string | string[]
 export type multilineString = string;
 
-export
-interface MimeBundle {
-    // values are always multilineString if we pretend that the application/json key doesn't exist
-    // in fact, the in-memory representation always is a string
-    [key: string]: multilineString;
-
-    // we fudge the standard a bit here by not telling Typescript about the application/json
-    // key, which will be a Javascript object if it exists.  If we want to tell, then uncomment below:
-    //"application/json": {};
-}
 
 export
 interface BaseOutput {

--- a/src/notebook/serialize.ts
+++ b/src/notebook/serialize.ts
@@ -27,9 +27,9 @@ import {
 } from '../output-area';
 
 import {
-  NBData, MarkdownCell, CodeCell, 
+  NBData, MarkdownCell, CodeCell,
   isMarkdownCell, isCodeCell,
-  DisplayData, isDisplayData, 
+  DisplayData, isDisplayData,
   ExecuteResult, isExecuteResult,
   Stream, isStream,
   JupyterError, isJupyterError, Output
@@ -47,7 +47,7 @@ function populateNotebookModel(nb: INotebookModel, data: NBData): void {
     let input = new InputAreaModel();
     input.textEditor = new EditorModel();
     input.textEditor.text = c.source;
-    
+
     if (isMarkdownCell(c)) {
       let cell = new MarkdownCellModel();
       cell.input = input;

--- a/src/notebook/widget.ts
+++ b/src/notebook/widget.ts
@@ -25,7 +25,7 @@ import {
 import {
   ICellModel, CellType,
     CodeCellWidget, MarkdownCellWidget,
-    CodeCellModel, MarkdownCellModel, isMarkdownCell
+    CodeCellModel, MarkdownCellModel, isMarkdownCellModel
 } from '../cells';
 
 import {
@@ -69,7 +69,7 @@ class NotebookWidget extends Panel {
       return w;
     })
     this.updateSelectedCell(model.selectedCellIndex);
-    
+
     // bind events that can select the cell
     // see https://github.com/jupyter/notebook/blob/203ccd3d4496cc22e6a1c5e6ece9f5a7d791472a/notebook/static/notebook/js/cell.js#L178
     this.node.addEventListener('click', (ev: MouseEvent) => {
@@ -81,7 +81,7 @@ class NotebookWidget extends Panel {
         return;
       }
       let cell = this._model.cells.get(i);
-      if (isMarkdownCell(cell) && cell.rendered) {
+      if (isMarkdownCellModel(cell) && cell.rendered) {
         cell.rendered = false;
         // TODO: focus the cell editor
       }
@@ -93,7 +93,7 @@ class NotebookWidget extends Panel {
 
   /**
    * Find the cell index containing the target html element.
-   * 
+   *
    * #### Notes
    * Returns -1 if the cell is not found.
    */
@@ -117,7 +117,7 @@ class NotebookWidget extends Panel {
   /**
    * Handle a change cells event.
    */
-  protected cellsChanged(sender: IObservableList<ICellModel>, 
+  protected cellsChanged(sender: IObservableList<ICellModel>,
                          args: IListChangedArgs<ICellModel>) {
     console.log(args);
   }
@@ -157,27 +157,27 @@ class NotebookWidget extends Panel {
     this._listdispose.dispose();
     super.dispose();
   }
-  
+
   /**
    * Get the model for the widget
    */
-  
+
   get model(): INotebookModel {
     return this._model;
   }
-  
+
   private _model: INotebookModel;
   private _listdispose: IDisposable;
 }
 
 /**
  * Make a panel mirror changes to an observable list.
- * 
+ *
  * @param source - The observable list.
  * @param sink - The Panel.
  * @param factory - A function which takes an item from the list and constructs a widget.
- */function follow<T>(source: IObservableList<T>, 
-                     sink: Panel, 
+ */function follow<T>(source: IObservableList<T>,
+                     sink: Panel,
                      factory: (arg: T)=> Widget): IDisposable {
 
   for (let i = sink.childCount()-1; i>=0; i--) {
@@ -215,5 +215,5 @@ class NotebookWidget extends Panel {
   return new DisposableDelegate(() => {
     source.changed.disconnect(callback);
   })
-  
+
 }

--- a/src/output-area/model.ts
+++ b/src/output-area/model.ts
@@ -80,7 +80,7 @@ class DisplayDataModel extends OutputBaseModel {
   * Metadata about the output.
   */
   metadata: any;
-  
+
   /**
    * Output type
    */
@@ -122,7 +122,7 @@ enum StreamName {
 /**
 * An output model for stream data.
 */
-export 
+export
 class StreamModel extends OutputBaseModel {
   /**
   * The type of stream.
@@ -163,12 +163,12 @@ class ExecuteErrorModel extends OutputBaseModel {
 
   /**
   * The traceback for the error.
-  * 
+  *
   * #### Notes
   * This is an array of strings that has been concatenated to a single string.
   */
   traceback: string;
-  
+
   /**
    * Output type
    */
@@ -179,9 +179,9 @@ class ExecuteErrorModel extends OutputBaseModel {
 /**
 * An output model that is one of the valid output types.
 */
-export 
+export
 type OutputModel = (
-  ExecuteResultModel | DisplayDataModel | StreamModel | 
+  ExecuteResultModel | DisplayDataModel | StreamModel |
   ExecuteErrorModel
 );
 
@@ -189,7 +189,7 @@ type OutputModel = (
 /**
 * The model for an output area.
 */
-export 
+export
 interface IOutputAreaModel {
 
   /**
@@ -218,7 +218,7 @@ interface IOutputAreaModel {
   outputs: ObservableList<OutputModel>;
 
   /**
-  * A convenience method to add an output to the end of the outputs list, 
+  * A convenience method to add an output to the end of the outputs list,
   * combining outputs if necessary.
   */
   add(output: OutputModel): void;
@@ -240,9 +240,9 @@ class OutputAreaModel implements IOutputAreaModel {
    * A signal emitted when the state of the model changes.
    *
    * #### Notes
-   * This will not trigger on changes to the output list. For output change handlers, 
-   * listen to [[outputs]] events directly.  
-   * 
+   * This will not trigger on changes to the output list. For output change handlers,
+   * listen to [[outputs]] events directly.
+   *
    * **See also:** [[stateChanged]]
    */
   static stateChangedSignal = new Signal<OutputAreaModel, IChangedArgs<any>>();
@@ -281,9 +281,9 @@ class OutputAreaModel implements IOutputAreaModel {
    * A signal emitted when the state of the model changes.
    *
    * #### Notes
-   * This will not trigger on changes to the output list. For output change handlers, 
+   * This will not trigger on changes to the output list. For output change handlers,
    * listen to [[outputs]] events directly.
-   * 
+   *
    * This is a pure delegate to the [[stateChangedSignal]].
    */
   get stateChanged() {
@@ -349,9 +349,9 @@ class OutputAreaModel implements IOutputAreaModel {
   set prompt(value: string) {
     OutputAreaModel.promptProperty.set(this, value);
   }
-  
+
   /**
-   * Add an output, which may be combined with previous output 
+   * Add an output, which may be combined with previous output
    * (e.g. for streams).
    */
   add(output: OutputModel) {
@@ -360,14 +360,14 @@ class OutputAreaModel implements IOutputAreaModel {
       this.clear();
       this._clearNext = false;
     }
-    
+
     // Consolidate outputs if they are stream outputs of the same kind
     let lastOutput = this.outputs.get(-1);
     if (isStreamModel(output)
         && lastOutput && isStreamModel(lastOutput)
         && output.name === lastOutput.name) {
-      // In order to get a list change event, we add the previous 
-      // text to the current item and replace the previous item. 
+      // In order to get a list change event, we add the previous
+      // text to the current item and replace the previous item.
       // This also replaces the metadata of the last item.
       output.text = lastOutput.text + output.text;
       this.outputs.set(-1, output);
@@ -378,7 +378,7 @@ class OutputAreaModel implements IOutputAreaModel {
 
   /**
   * Clear all of the output.
-  * 
+  *
   * @param wait Delay clearing the output until the next message is added.
   */
   clear(wait: boolean = false) {
@@ -390,7 +390,7 @@ class OutputAreaModel implements IOutputAreaModel {
   }
 
   outputs = new ObservableList<OutputModel>();
-  
+
   /**
    * Whether to clear on the next message add.
    */


### PR DESCRIPTION
This caused issues when consuming the library:

``` typescript
node_modules/jupyter-js-notebook/lib/index.d.ts(3,1): error TS2308: Module './cells/index' has already exported a member named 'isCodeCell'. Consider explicitly re-exporting to resolve the ambiguity.
node_modules/jupyter-js-notebook/lib/index.d.ts(3,1): error TS2308: Module './cells/index' has already exported a member named 'isMarkdownCell'. Consider explicitly re-exporting to resolve the ambiguity.
node_modules/jupyter-js-notebook/lib/index.d.ts(4,1): error TS2308: Module './notebook/index' has already exported a member named 'MimeBundle'. Consider explicitly re-exporting to resolve the ambiguity.
node_modules/jupyter-js-notebook/lib/index.d.ts(3,1): error TS2308: Module './cells/index' has already exported a member named 'isCodeCell'. Consider explicitly re-exporting to resolve the ambiguity.
node_modules/jupyter-js-notebook/lib/index.d.ts(3,1): error TS2308: Module './cells/index' has already exported a member named 'isMarkdownCell'. Consider explicitly re-exporting to resolve the ambiguity.
node_modules/jupyter-js-notebook/lib/index.d.ts(4,1): error TS2308: Module './notebook/index' has already exported a member named 'MimeBundle'. Consider explicitly re-exporting to resolve the ambiguity.
```
