### PR TITLE
Only export the notebook symbols by default.

### DIFF
--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -7,8 +7,11 @@ import {
 import {
   NotebookModel, NotebookWidget,
   NBData, populateNotebookModel,
-  isMarkdownCellModel
 } from '../../lib/index';
+
+import {
+  isMarkdownCellModel
+} from '../../lib/cells'
 
 import {
   IKeyBinding, KeymapManager, keystrokeForKeydownEvent

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,4 @@
 // Distributed under the terms of the Modified BSD License.
 'use strict';
 
-export * from './cells/index';
-export * from './input-area/index';
 export * from './notebook/index';
-export * from './output-area/index';


### PR DESCRIPTION
This will cut down on the huge number of symbols and name conflicts, etc. Import from 'subpackages' by doing something like `jupyter-js-notebook/cells`, etc.
