### PR TITLE
Export cells as a namespace

### DIFF
--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -6,12 +6,8 @@ import {
 
 import {
   NotebookModel, NotebookWidget,
-  NBData, populateNotebookModel,
+  NBData, populateNotebookModel, cells
 } from '../../lib/index';
-
-import {
-  isMarkdownCellModel
-} from '../../lib/cells'
 
 import {
   IKeyBinding, KeymapManager, keystrokeForKeydownEvent
@@ -42,7 +38,7 @@ function bindings(nbModel: NotebookModel) {
         handler: args => {
         if (nbModel.selectedCellIndex !== void 0) {
           let cell = nbModel.cells.get(nbModel.selectedCellIndex);
-          if (isMarkdownCellModel(cell) && !cell.rendered) {
+          if (cells.isMarkdownCellModel(cell) && !cell.rendered) {
             cell.rendered = true;
           }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,6 @@
 'use strict';
 
 export * from './notebook/index';
+
+import * as _cells from './cells/index';
+export const cells = _cells;


### PR DESCRIPTION
This allows use to import from `jupyter-js-notebook/cells` instead of `jupyter-js-input/lib/cells`.
