### PR TITLE
Fix circular notification problem

### DIFF
--- a/src/editor/widget.ts
+++ b/src/editor/widget.ts
@@ -142,8 +142,10 @@ class CodeMirrorWidget extends Widget implements IEditorWidget {
     this.updateFixedHeight(model.fixedHeight);
     this.updateText(model.text);
     CodeMirror.on(this._editor.getDoc(), 'change', (instance, change) => {
-      this._model.text = instance.getValue();
-      this._model.dirty = true;
+      if (change.origin !== 'setValue') {
+        this._model.text = instance.getValue();
+        this._model.dirty = true;
+      }
     });
     this._editor.on('focus', () => {
       this._model.focused = true;


### PR DESCRIPTION
We needed a way to differentiate between an input action from the user and a programmatic setting of the text, which was provided by the `change.origin` field in the CodeMirror change handler.

Now if the change is made programmatically, it is up to the one making the changes whether to set the dirty flag.  Input from the user will always set the dirty flag.
