### PR TITLE
Cleanup

### DIFF
--- a/src/cells/model.ts
+++ b/src/cells/model.ts
@@ -181,21 +181,21 @@ class BaseCellModel implements IBaseCellModel {
    * A signal emitted when the state of the model changes.
    */
   get stateChanged(): ISignal<IBaseCellModel, IChangedArgs<any>> {
-    return Private.stateChangedSignal.bind(this);
+    return CellModelPrivate.stateChangedSignal.bind(this);
   }
 
   /**
    * Get whether the cell is the active cell in the notebook.
    */
   get active(): boolean {
-    return Private.activeProperty.get(this);
+    return CellModelPrivate.activeProperty.get(this);
   }
 
   /**
    * Set whether the cell is the active cell in the notebook.
    */
   set active(value: boolean) {
-    Private.activeProperty.set(this, value);
+    CellModelPrivate.activeProperty.set(this, value);
   }
 
   /**
@@ -226,14 +226,14 @@ class BaseCellModel implements IBaseCellModel {
    * Get whether the cell is selected for applying commands.
    */
   get selected(): boolean {
-    return Private.selectedProperty.get(this);
+    return CellModelPrivate.selectedProperty.get(this);
   }
 
   /**
    * Set whether the cell is selected for applying commands.
    */
   set selected(value: boolean) {
-    Private.selectedProperty.set(this, value);
+    CellModelPrivate.selectedProperty.set(this, value);
   }
 
   /**
@@ -287,28 +287,28 @@ class BaseCellModel implements IBaseCellModel {
    * Get the name of the cell.
    */
   get name(): string {
-    return Private.nameProperty.get(this);
+    return CellModelPrivate.nameProperty.get(this);
   }
 
   /**
    * Set the name of the cell.
    */
   set name(value: string) {
-    Private.nameProperty.set(this, value);
+    CellModelPrivate.nameProperty.set(this, value);
   }
 
   /**
    * Get the tags for the cell.
    */
   get tags(): string[] {
-    return Private.tagsProperty.get(this);
+    return CellModelPrivate.tagsProperty.get(this);
   }
 
   /**
    * Set the tags for the cell.
    */
   set tags(value: string[]) {
-    Private.tagsProperty.set(this, value);
+    CellModelPrivate.tagsProperty.set(this, value);
   }
 
   /**
@@ -377,14 +377,14 @@ class CodeCellModel extends BaseCellModel implements ICodeCellModel {
    * Get the execution count.
    */
   get executionCount(): number {
-    return Private.executionCountProperty.get(this);
+    return CellModelPrivate.executionCountProperty.get(this);
   }
 
   /**
    * Set the execution count.
    */
   set executionCount(value: number) {
-    Private.executionCountProperty.set(this, value);
+    CellModelPrivate.executionCountProperty.set(this, value);
     this.input.prompt = `In [${value === null ? ' ' : value}]:`;
   }
 
@@ -392,28 +392,28 @@ class CodeCellModel extends BaseCellModel implements ICodeCellModel {
    * Get whether the cell is collapsed/expanded.
    */
   get collapsed(): boolean {
-    return Private.collapsedProperty.get(this);
+    return CellModelPrivate.collapsedProperty.get(this);
   }
 
   /**
    * Set whether the cell is collapsed/expanded.
    */
   set collapsed(value: boolean) {
-    Private.collapsedProperty.set(this, value);
+    CellModelPrivate.collapsedProperty.set(this, value);
   }
 
   /**
    * Get whether the cell's output is scrolled, unscrolled, or autoscrolled.
    */
   get scrolled(): boolean | 'auto' {
-    return Private.scrolledProperty.get(this);
+    return CellModelPrivate.scrolledProperty.get(this);
   }
 
   /**
    * Set whether the cell's output is scrolled, unscrolled, or autoscrolled.
    */
   set scrolled(value: boolean | 'auto') {
-    Private.scrolledProperty.set(this, value);
+    CellModelPrivate.scrolledProperty.set(this, value);
   }
 
   type: CellType = "code";
@@ -431,14 +431,14 @@ class MarkdownCellModel extends BaseCellModel implements IMarkdownCellModel {
    * Get whether we should display a rendered representation.
    */
   get rendered() {
-    return Private.renderedProperty.get(this);
+    return CellModelPrivate.renderedProperty.get(this);
   }
 
   /**
    * Set whether we should display a rendered representation.
    */
   set rendered(value: boolean) {
-    Private.renderedProperty.set(this, value);
+    CellModelPrivate.renderedProperty.set(this, value);
   }
 
   type: CellType = "markdown";
@@ -454,14 +454,14 @@ class RawCellModel extends BaseCellModel implements IRawCellModel {
    * Get the raw cell metadata format for nbconvert.
    */
   get format(): string {
-    return Private.formatProperty.get(this);
+    return CellModelPrivate.formatProperty.get(this);
   }
 
   /**
    * Set the raw cell metadata format for nbconvert.
    */
   set format(value: string) {
-    Private.formatProperty.set(this, value);
+    CellModelPrivate.formatProperty.set(this, value);
   }
 
   type: CellType = "raw";
@@ -496,7 +496,7 @@ function isRawCellModel(m: ICellModel): m is IRawCellModel {
 /**
  * A namespace for cell private data.
  */
-namespace Private {
+namespace CellModelPrivate {
   /**
    * A signal emitted when the state of the model changes.
    */

--- a/src/cells/model.ts
+++ b/src/cells/model.ts
@@ -223,14 +223,14 @@ class BaseCellModel implements IBaseCellModel {
   }
 
   /**
-   * Get wether the cell is selected for applying commands.
+   * Get whether the cell is selected for applying commands.
    */
   get selected(): boolean {
     return Private.selectedProperty.get(this);
   }
 
   /**
-   * Set wether the cell is selected for applying commands.
+   * Set whether the cell is selected for applying commands.
    */
   set selected(value: boolean) {
     Private.selectedProperty.set(this, value);
@@ -435,7 +435,7 @@ class MarkdownCellModel extends BaseCellModel implements IMarkdownCellModel {
   }
 
   /**
-   * Get whether we should display a rendered representation.
+   * Set whether we should display a rendered representation.
    */
   set rendered(value: boolean) {
     Private.renderedProperty.set(this, value);
@@ -458,7 +458,7 @@ class RawCellModel extends BaseCellModel implements IRawCellModel {
   }
 
   /**
-   * Get the raw cell metadata format for nbconvert.
+   * Set the raw cell metadata format for nbconvert.
    */
   set format(value: string) {
     Private.formatProperty.set(this, value);

--- a/src/cells/model.ts
+++ b/src/cells/model.ts
@@ -41,6 +41,11 @@ import {
 export
 type CellMode = 'command' | 'edit';
 
+/**
+ * The scrolled setting of a cell.
+ */
+export
+type ScrollSetting = boolean | 'auto';
 
 /**
  * The definition of a model object for a base cell.
@@ -125,7 +130,7 @@ interface ICodeCellModel extends IBaseCellModel {
   /**
    * Whether the cell's output is scrolled, unscrolled, or autoscrolled.
    */
-  scrolled?: boolean | 'auto';
+  scrolled?: ScrollSetting;
 }
 
 
@@ -360,10 +365,10 @@ class CodeCellModel extends BaseCellModel implements ICodeCellModel {
   /**
    * Whether the cell's output is scrolled, unscrolled, or autoscrolled.
    */
-  get scrolled(): boolean | 'auto' {
+  get scrolled(): ScrollSetting {
     return CellModelPrivate.scrolledProperty.get(this);
   }
-  set scrolled(value: boolean | 'auto') {
+  set scrolled(value: ScrollSetting) {
     CellModelPrivate.scrolledProperty.set(this, value);
   }
 
@@ -526,7 +531,7 @@ namespace CellModelPrivate {
   * A property descriptor for the scrolled state of a code cell.
   */
   export
-  const scrolledProperty = new Property<ICodeCellModel, boolean | 'auto'>({
+  const scrolledProperty = new Property<ICodeCellModel, ScrollSetting>({
     name: 'scrolled',
     notify: stateChangedSignal,
   });

--- a/src/cells/model.ts
+++ b/src/cells/model.ts
@@ -185,21 +185,17 @@ class BaseCellModel implements IBaseCellModel {
   }
 
   /**
-   * Get whether the cell is the active cell in the notebook.
+   * Whether the cell is the active cell in the notebook.
    */
   get active(): boolean {
     return CellModelPrivate.activeProperty.get(this);
   }
-
-  /**
-   * Set whether the cell is the active cell in the notebook.
-   */
   set active(value: boolean) {
     CellModelPrivate.activeProperty.set(this, value);
   }
 
   /**
-   * Get mode of the cell.
+   * The mode of the cell.
    *
    * #### Notes
    * This is a delegate to the focused state of the input's editor.
@@ -211,27 +207,16 @@ class BaseCellModel implements IBaseCellModel {
       return 'command';
     }
   }
-
-  /**
-   * Set mode of the cell.
-   *
-   * #### Notes
-   * This is a delegate to the focused state of the input's editor.
-   */
   set mode(value: CellMode) {
     this.input.textEditor.focused = value === 'edit';
   }
 
   /**
-   * Get whether the cell is selected for applying commands.
+   * Whether the cell is selected for applying commands.
    */
   get selected(): boolean {
     return CellModelPrivate.selectedProperty.get(this);
   }
-
-  /**
-   * Set whether the cell is selected for applying commands.
-   */
   set selected(value: boolean) {
     CellModelPrivate.selectedProperty.set(this, value);
   }
@@ -244,7 +229,7 @@ class BaseCellModel implements IBaseCellModel {
   }
 
   /**
-   * Get the dirty state of the cell.
+   * The dirty state of the cell.
    *
    * #### Notes
    * This is a delegate to the dirty state of the [input].
@@ -252,19 +237,12 @@ class BaseCellModel implements IBaseCellModel {
   get dirty(): boolean {
     return this.input.dirty;
   }
-
-  /**
-   * Set the dirty state of the cell.
-   *
-   * #### Notes
-   * This is a delegate to the dirty state of the [input].
-   */
   set dirty(value: boolean) {
     this.input.dirty = value;
   }
 
   /**
-   * Get the read only state of the cell.
+   * The read only state of the cell.
    *
    * #### Notes
    * This is a delegate to the read only state of the [input].
@@ -272,41 +250,26 @@ class BaseCellModel implements IBaseCellModel {
   get readOnly(): boolean {
     return this.input.readOnly;
   }
-
-  /**
-   * Set the read only state of the cell.
-   *
-   * #### Notes
-   * This is a delegate to the read only state of the [input].
-   */
   set readOnly(value: boolean) {
     this.input.readOnly = value;
   }
 
   /**
-   * Get the name of the cell.
+   * The name of the cell.
    */
   get name(): string {
     return CellModelPrivate.nameProperty.get(this);
   }
-
-  /**
-   * Set the name of the cell.
-   */
   set name(value: string) {
     CellModelPrivate.nameProperty.set(this, value);
   }
 
   /**
-   * Get the tags for the cell.
+   * The tags for the cell.
    */
   get tags(): string[] {
     return CellModelPrivate.tagsProperty.get(this);
   }
-
-  /**
-   * Set the tags for the cell.
-   */
   set tags(value: string[]) {
     CellModelPrivate.tagsProperty.set(this, value);
   }
@@ -374,44 +337,32 @@ class CodeCellModel extends BaseCellModel implements ICodeCellModel {
   }
 
   /**
-   * Get the execution count.
+   * The execution count.
    */
   get executionCount(): number {
     return CellModelPrivate.executionCountProperty.get(this);
   }
-
-  /**
-   * Set the execution count.
-   */
   set executionCount(value: number) {
     CellModelPrivate.executionCountProperty.set(this, value);
     this.input.prompt = `In [${value === null ? ' ' : value}]:`;
   }
 
   /**
-   * Get whether the cell is collapsed/expanded.
+   * Whether the cell is collapsed/expanded.
    */
   get collapsed(): boolean {
     return CellModelPrivate.collapsedProperty.get(this);
   }
-
-  /**
-   * Set whether the cell is collapsed/expanded.
-   */
   set collapsed(value: boolean) {
     CellModelPrivate.collapsedProperty.set(this, value);
   }
 
   /**
-   * Get whether the cell's output is scrolled, unscrolled, or autoscrolled.
+   * Whether the cell's output is scrolled, unscrolled, or autoscrolled.
    */
   get scrolled(): boolean | 'auto' {
     return CellModelPrivate.scrolledProperty.get(this);
   }
-
-  /**
-   * Set whether the cell's output is scrolled, unscrolled, or autoscrolled.
-   */
   set scrolled(value: boolean | 'auto') {
     CellModelPrivate.scrolledProperty.set(this, value);
   }
@@ -428,15 +379,11 @@ class CodeCellModel extends BaseCellModel implements ICodeCellModel {
 export
 class MarkdownCellModel extends BaseCellModel implements IMarkdownCellModel {
   /**
-   * Get whether we should display a rendered representation.
+   * Whether we should display a rendered representation.
    */
   get rendered() {
     return CellModelPrivate.renderedProperty.get(this);
   }
-
-  /**
-   * Set whether we should display a rendered representation.
-   */
   set rendered(value: boolean) {
     CellModelPrivate.renderedProperty.set(this, value);
   }
@@ -451,15 +398,11 @@ class MarkdownCellModel extends BaseCellModel implements IMarkdownCellModel {
 export
 class RawCellModel extends BaseCellModel implements IRawCellModel {
   /**
-   * Get the raw cell metadata format for nbconvert.
+   * The raw cell metadata format for nbconvert.
    */
   get format(): string {
     return CellModelPrivate.formatProperty.get(this);
   }
-
-  /**
-   * Set the raw cell metadata format for nbconvert.
-   */
   set format(value: string) {
     CellModelPrivate.formatProperty.set(this, value);
   }

--- a/src/editor/model.ts
+++ b/src/editor/model.ts
@@ -248,8 +248,8 @@ namespace EditorModelPrivate {
   export
   const fixedHeightProperty = new Property<EditorModel, boolean>({
     name: 'fixedHeight',
-    notify: stateChangedSignal,
     value: false,
+    notify: stateChangedSignal,
   });
 
   /**

--- a/src/editor/model.ts
+++ b/src/editor/model.ts
@@ -10,9 +10,69 @@ import {
   ISignal, Signal
 } from 'phosphor-signaling';
 
-import {
-  IEditorModel
-} from './widget';
+
+/**
+ * An interface required for implementing the editor model
+ */
+export
+interface IEditorModel {
+  /**
+   * A signal emitted when the editor model state changes.
+   */
+  stateChanged: ISignal<IEditorModel, IChangedArgs<any>>;
+
+  /**
+   * The text in the text editor.
+   */
+  text: string;
+
+  /**
+   * The mimetype of the text.
+   *
+   * #### Notes
+   * The mimetype is used to set the syntax highlighting, for example.
+   */
+  mimetype: string;
+
+  /**
+   * The filename of the editor.
+   */
+  filename: string;
+
+  /**
+   * Whether the editor is focused.
+   */
+  focused: boolean;
+
+  /**
+   * Whether the text editor has a fixed maximum height.
+   *
+   * #### Notes
+   * If true, the editor has a fixed maximum height.  If false, the editor
+   * resizes to fit the content.
+   */
+  fixedHeight: boolean;
+
+  /**
+   * A flag to determine whether to show line numbers.
+   */
+  lineNumbers: boolean;
+
+  /**
+   * A property to determine whether to allow editing.
+   */
+  readOnly: boolean;
+
+  /**
+   * The number of spaces to insert for each tab.
+   */
+  tabSize: number;
+
+  /**
+   * Whether the editor has unsaved changes.
+   */
+  dirty: boolean;
+}
 
 
 /**

--- a/src/editor/model.ts
+++ b/src/editor/model.ts
@@ -145,126 +145,91 @@ class EditorModel implements IEditorModel {
   }
 
   /**
-   * Get the dirty state for the editor.
+   * The dirty state for the editor.
    */
   get dirty(): boolean {
     return EditorModelPrivate.dirtyProperty.get(this);
   }
-
-  /**
-   * Set the dirty state for the editor.
-   */
   set dirty(value: boolean) {
     EditorModelPrivate.dirtyProperty.set(this, value);
   }
 
   /**
-   * Get the mode for the editor filename.
+   * The mode for the editor filename.
    */
   get filename(): string {
     return EditorModelPrivate.filenameProperty.get(this);
   }
-
-  /**
-   * Set the text for the editor filename.
-   */
   set filename(value: string) {
     EditorModelPrivate.filenameProperty.set(this, value);
   }
 
   /**
-   * Get whether the editor height should be constrained.
+   * Whether the editor height should be constrained.
    */
   get fixedHeight() {
     return EditorModelPrivate.fixedHeightProperty.get(this);
   }
-
-  /**
-   * Set whether the editor height should be constrained.
-   */
   set fixedHeight(value: boolean) {
     EditorModelPrivate.fixedHeightProperty.set(this, value);
   }
 
   /**
-   * Get the mode for the editor mimetype.
+   * The mode for the editor mimetype.
    */
   get mimetype(): string {
     return EditorModelPrivate.mimetypeProperty.get(this);
   }
-
-  /**
-   * Set the text for the editor mimetype.
-   */
   set mimetype(value: string) {
     EditorModelPrivate.mimetypeProperty.set(this, value);
   }
 
   /**
-   * Get the lineNumbers flag for the editor model.
+   * The lineNumbers flag for the editor model.
    */
   get lineNumbers(): boolean {
     return EditorModelPrivate.lineNumbersProperty.get(this);
   }
-
-  /**
-   * Set the lineNumbers flag for the editor model.
-   */
   set lineNumbers(value: boolean) {
     EditorModelPrivate.lineNumbersProperty.set(this, value);
   }
 
   /**
-   * Get the readOnly property for the editor model.
+   * The readOnly property for the editor model.
    */
   get readOnly(): boolean {
     return EditorModelPrivate.readOnlyProperty.get(this);
   }
-
-  /**
-   * Set the readOnly property for the editor model.
-   */
   set readOnly(value: boolean) {
     EditorModelPrivate.readOnlyProperty.set(this, value);
   }
+
   /**
-   * Get whether the editor is focused for editing.
+   * Whether the editor is focused for editing.
    */
   get focused(): boolean {
     return EditorModelPrivate.focusedProperty.get(this);
   }
-
-  /**
-   * Set whether the editor is focused for editing.
-   */
   set focused(value: boolean) {
     EditorModelPrivate.focusedProperty.set(this, value);
   }
 
   /**
-   * Get the tabSize number for the editor model.
+   * The tabSize number for the editor model.
    */
   get tabSize(): number {
     return EditorModelPrivate.tabSizeProperty.get(this);
   }
-
-  /**
-   * Set the tabSize number for the editor model.
-   */
   set tabSize(value: number) {
     EditorModelPrivate.tabSizeProperty.set(this, value);
   }
 
   /**
-   * Get the text of the editor model.
+   * The text of the editor model.
    */
   get text(): string {
     return EditorModelPrivate.textProperty.get(this);
   }
-
-  /**
-   * Set the text on the editor model.
-   */
   set text(value: string) {
     EditorModelPrivate.textProperty.set(this, value);
   }

--- a/src/editor/widget.ts
+++ b/src/editor/widget.ts
@@ -28,6 +28,10 @@ import {
   ResizeMessage, Widget
 } from 'phosphor-widget';
 
+import {
+  IEditorModel
+} from './model';
+
 
 /**
  * The class name added to CodeMirrorWidget instances.
@@ -44,71 +48,6 @@ const FIXED_HEIGHT_CLASS = 'jp-mod-fixedHeight';
  */
 let diffMatchPatch = new dmp.diff_match_patch();
 
-
-/**
- * An interface required for implementing the editor model
- */
-export
-interface IEditorModel {
-  /**
-   * A signal emitted when the editor model state changes.
-   */
-  stateChanged: ISignal<IEditorModel, IChangedArgs<any>>;
-
-  /**
-   * The text in the text editor.
-   */
-  text: string;
-
-  /**
-   * The mimetype of the text.
-   *
-   * #### Notes
-   * The mimetype is used to set the syntax highlighting, for example.
-   */
-  mimetype: string;
-
-  /**
-   * The filename of the editor.
-   */
-  filename: string;
-
-  /**
-   * Whether the editor is focused.
-   */
-  focused: boolean;
-
-  /**
-   * Whether the text editor has a fixed maximum height.
-   *
-   * #### Notes
-   * If true, the editor has a fixed maximum height.  If false, the editor
-   * resizes to fit the content.
-   */
-  fixedHeight: boolean;
-
-  /**
-   * A flag to determine whether to show line numbers.
-   */
-  lineNumbers: boolean;
-
-  /**
-   * A property to determine whether to allow editing.
-   */
-  readOnly: boolean;
-
-  /**
-   * The number of spaces to insert for each tab.
-   */
-  tabSize: number;
-
-  /**
-   * Whether the editor has unsaved changes.
-   */
-  dirty: boolean;
-}
-
-
 /**
  * The interface for an editor widget.
  */
@@ -119,7 +58,6 @@ interface IEditorWidget extends Widget {
    */
   model: IEditorModel;
 }
-
 
 /**
  * A widget which hosts a CodeMirror editor.

--- a/src/input-area/model.ts
+++ b/src/input-area/model.ts
@@ -73,29 +73,21 @@ class InputAreaModel implements IInputAreaModel {
   }
 
   /**
-   * Get whether the input area should be collapsed or displayed.
+   * Whether the input area should be collapsed or displayed.
    */
   get collapsed() {
     return InputAreaModelPrivate.collapsedProperty.get(this);
   }
-
-  /**
-   * Set whether the input area should be collapsed or displayed.
-   */
   set collapsed(value: boolean) {
     InputAreaModelPrivate.collapsedProperty.set(this, value);
   }
 
   /**
-   * Get the prompt text.
+   * The prompt text.
    */
   get prompt() {
     return InputAreaModelPrivate.promptProperty.get(this);
   }
-
-  /**
-   * Set the prompt text.
-   */
   set prompt(value: string) {
     InputAreaModelPrivate.promptProperty.set(this, value);
   }
@@ -111,7 +103,7 @@ class InputAreaModel implements IInputAreaModel {
   }
 
   /**
-   * Get the dirty state.
+   * The dirty state.
    *
    * #### Notest
    * This is a delegate to the dirty state of the [textEditor].
@@ -119,27 +111,16 @@ class InputAreaModel implements IInputAreaModel {
   get dirty(): boolean {
     return this.textEditor.dirty;
   }
-
-  /**
-   * Set the dirty state.
-   *
-   * #### Notest
-   * This is a delegate to the dirty state of the [textEditor].
-   */
   set dirty(value: boolean) {
     this.textEditor.dirty = value;
   }
 
   /**
-   * Get the read only state.
+   * The read only state.
    */
   get readOnly(): boolean {
     return this.textEditor.readOnly;
   }
-
-  /**
-   * Set the read only state.
-   */
   set readOnly(value: boolean) {
     this.textEditor.readOnly = value;
   }

--- a/src/notebook/model.ts
+++ b/src/notebook/model.ts
@@ -259,8 +259,7 @@ class NotebookModel implements INotebookModel {
    *
    * #### Notes
    * The value will be clamped.  When setting this, all other cells 
-   * will be marked as inactive. The active cell will also be marked 
-   * as selected.
+   * will be marked as inactive.
    */
   get activeCellIndex(): number {
     return NotebookModelPrivate.activeCellIndexProperty.get(this);

--- a/src/notebook/model.ts
+++ b/src/notebook/model.ts
@@ -211,29 +211,21 @@ class NotebookModel implements INotebookModel {
   }
 
   /**
-   * Get the default mimetype for cells new code cells.
+   * The default mimetype for cells new code cells.
    */
   get defaultMimetype(): string {
     return NotebookModelPrivate.defaultMimetype.get(this);
   }
-
-  /**
-   * Set the default mimetype for cells new code cells.
-   */
   set defaultMimetype(value: string) {
     NotebookModelPrivate.defaultMimetype.set(this, value);
   }
 
   /**
-   * Get the read-only status of the notebook.
+   * The read-only status of the notebook.
    */
   get readOnly(): boolean {
     return NotebookModelPrivate.readOnlyProperty.get(this);
   }
-
-  /**
-   * Set the read-only status of the notebook.
-   */
   set readOnly(value: boolean) {
     NotebookModelPrivate.readOnlyProperty.set(this, value);
     let cells = this._cells;
@@ -243,47 +235,36 @@ class NotebookModel implements INotebookModel {
   }
 
   /**
-   * Get the session for the notebook.
+   * The session for the notebook.
    */
   get session(): INotebookSession {
     return NotebookModelPrivate.sessionProperty.get(this);
   }
-
-  /**
-   * Set the session for the notebook.
-   */
   set session(value: INotebookSession) {
     NotebookModelPrivate.sessionProperty.set(this, value);
   }
 
   /**
-   * Get the metadata for the notebook.
+   * The metadata for the notebook.
    */
   get metadata(): INotebookMetadata {
     return NotebookModelPrivate.metadataProperty.get(this);
   }
-
-  /**
-   * Set the metadata for the notebook.
-   */
   set metadata(value: INotebookMetadata) {
     NotebookModelPrivate.metadataProperty.set(this, value);
   }
 
   /**
-   * Get the index of the active cell.
+   * The index of the active cell.
+   *
+   * #### Notes
+   * The value will be clamped.  When setting this, all other cells 
+   * will be marked as inactive. The active cell will also be marked 
+   * as selected.
    */
   get activeCellIndex(): number {
     return NotebookModelPrivate.activeCellIndexProperty.get(this);
   }
-
-  /**
-   * Set the index of the active cell.  
-   *
-   * #### Notes
-   * The value will be clamped.  All other cells will be marked as inactive.
-   * The active cell will also be marked as selected.
-   */
   set activeCellIndex(value: number) {
     value = Math.max(value, 0);
     value = Math.min(value, this.cells.length - 1);
@@ -296,15 +277,11 @@ class NotebookModel implements INotebookModel {
   }
 
   /**
-   * Get whether the notebook has unsaved changes.
+   * Whether the notebook has unsaved changes.
    */
   get dirty(): boolean {
     return NotebookModelPrivate.dirtyProperty.get(this);
   }
-
-  /**
-   * Set whether the notebook has unsaved changes.
-   */
   set dirty(value: boolean) {
     // Clear the dirty state of all cells if the notebook dirty state
     // is cleared.

--- a/src/output-area/model.ts
+++ b/src/output-area/model.ts
@@ -70,29 +70,21 @@ class OutputAreaModel implements IOutputAreaModel {
   }
 
   /**
-   * Get whether the output has a maximum fixed height.
+   * Whether the output has a maximum fixed height.
    */
   get fixedHeight() {
     return Private.fixedHeightProperty.get(this);
   }
-
-  /**
-   * Set whether the output has a maximum fixed height.
-   */
   set fixedHeight(value: boolean) {
     Private.fixedHeightProperty.set(this, value);
   }
 
   /**
-   * Get whether the input area should be collapsed or displayed.
+   * Whether the input area should be collapsed or displayed.
    */
   get collapsed() {
     return Private.collapsedProperty.get(this);
   }
-
-  /**
-   * Set whether the input area should be collapsed or displayed.
-   */
   set collapsed(value: boolean) {
     Private.collapsedProperty.set(this, value);
   }


### PR DESCRIPTION
I made a number of clean-up changes in the code/docs. I think they are all pretty benign, except for possibly the change to compress the documentation for get/set pairs of functions. Typedoc recognizes that a get/set pair really emulates an attribute, so having separate documentation for each function isn't needed. It makes much more of the code fit in the vertical space, so I like the change. @blink1073 - thoughts?
