### PR TITLE
Add a Kernel Selector

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -3,7 +3,6 @@
   "name": "jupyter-js-notebook-example",
   "dependencies": {
     "jupyter-js-notebook": "file:..",
-    "jupyter-js-utils": "^0.3.1",
     "phosphor-commandpalette": "^0.2.0",
     "phosphor-keymap": "^0.7.0",
     "phosphor-splitpanel": "^1.0.0-rc.1"

--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -7,7 +7,7 @@
 
 import {
   NotebookModel, ActiveNotebook, INotebookContent, NotebookManager,
-  serialize, deserialize, trustNotebook
+  serialize, deserialize, selectKernel, trustNotebook
 } from 'jupyter-js-notebook';
 
 import {
@@ -15,7 +15,8 @@ import {
 } from 'jupyter-js-notebook/lib/cells'
 
 import {
-  ContentsManager, IContentsModel, startNewSession
+  ContentsManager, IContentsModel, IKernelSpecIds, startNewSession, 
+  getKernelSpecs
 } from 'jupyter-js-services';
 
 import {
@@ -33,6 +34,10 @@ import {
 import {
   SplitPanel
 } from 'phosphor-splitpanel';
+
+import {
+  Widget
+} from 'phosphor-widget';
 
 import 'jupyter-js-notebook/lib/index.css';
 import 'jupyter-js-notebook/lib/theme.css';
@@ -75,12 +80,28 @@ function main(): void {
   panel.addChild(nbWidget);
   window.onresize = () => { panel.update(); };
 
+  let kernelspecs: IKernelSpecIds;
+  getKernelSpecs({}).then(specs => {
+    kernelspecs = specs;
+  });
+
+    
   let items: IStandardPaletteItemOptions[] = [
   {
     category: 'Notebook',
     text: 'Save',
     shortcut: 'Accel S',
     handler: () => { nbManager.save() ; }
+  },
+  {
+    category: 'Notebook',
+    text: 'Change Kernel',
+    handler: () => { 
+      if (!kernelspecs) {
+        return;
+      }
+      selectKernel(nbWidget.node, nbModel, kernelspecs);
+    }
   },
   {
     category: 'Notebook',
@@ -187,6 +208,7 @@ function main(): void {
   },
   ]
   pModel.addItems(items);
+
 
   let bindings = [
   {

--- a/example/test.ipynb
+++ b/example/test.ipynb
@@ -50,7 +50,7 @@
    "source": [
     "# Markdown Cell\n",
     "\n",
-    "$ e^{ \\pm i\\theta } = \\cos \\theta \\pm i\\sin \\theta $\n",
+    "$ e^{ \\pm i\\theta } = \\cos \\theta \\pm i\\sin \\theta + \\beta $\n",
     "\n",
     "*It* **really** is!"
    ]

--- a/example/webpack.conf.js
+++ b/example/webpack.conf.js
@@ -2,8 +2,8 @@
 module.exports = {
   entry: './build/index.js',
   output: {
-    path: './build',
-    filename: 'bundle.js'
+    filename: './build/bundle.js',
+    chunkFilename: "./build/[id].bundle.js"
   },
   debug: true,
   module: {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "codemirror": "^5.11.0",
     "diff-match-patch": "^1.0.0",
-    "jupyter-js-services": "file:../services",
+    "jupyter-js-services": "^0.6.4",
     "jupyter-js-ui": "^0.2.0",
     "jupyter-js-utils": "^0.3.3",
     "marked": "^0.3.5",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   "dependencies": {
     "codemirror": "^5.11.0",
     "diff-match-patch": "^1.0.0",
-    "jupyter-js-services": "^0.6.1",
+    "jupyter-js-services": "file:../services",
     "jupyter-js-ui": "^0.2.0",
+    "jupyter-js-utils": "^0.3.3",
     "marked": "^0.3.5",
     "phosphor-disposable": "^1.0.5",
     "phosphor-observablelist": "^1.0.0-beta",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "codemirror": "^5.11.0",
     "diff-match-patch": "^1.0.0",
-    "jupyter-js-services": "^0.6.4",
+    "jupyter-js-services": "^0.6.6",
     "jupyter-js-ui": "^0.2.0",
     "jupyter-js-utils": "^0.3.3",
     "marked": "^0.3.5",

--- a/src/notebook/codemirror-ipython.ts
+++ b/src/notebook/codemirror-ipython.ts
@@ -22,11 +22,7 @@ CodeMirror.defineMode('ipython', (config: CodeMirror.EditorConfiguration, modeOp
     }
     pythonConf.name = 'python';
     pythonConf.singleOperators = new RegExp('^[\\+\\-\\*/%&|\\^~<>!\\?]');
-    if (pythonConf.version === 3) {
-        pythonConf.identifiers = new RegExp('^[_A-Za-z\u00A1-\uFFFF][_A-Za-z0-9\u00A1-\uFFFF]*');
-    } else if (pythonConf.version === 2) {
-      pythonConf.identifiers = new RegExp('^[_A-Za-z][_A-Za-z0-9]*');
-    }
+    pythonConf.identifiers = new RegExp('^[_A-Za-z\u00A1-\uFFFF][_A-Za-z0-9\u00A1-\uFFFF]*');
     return CodeMirror.getMode(config, pythonConf);
 });
 

--- a/src/notebook/index.ts
+++ b/src/notebook/index.ts
@@ -6,5 +6,6 @@ export * from './model';
 export * from './nbformat';
 export * from './manager';
 export * from './serialize';
+export * from './selector';
 export * from './trust';
 export * from './widget';

--- a/src/notebook/model.ts
+++ b/src/notebook/model.ts
@@ -629,6 +629,8 @@ namespace NotebookModelPrivate {
    */
   function sessionChanged(model: NotebookModel, session: INotebookSession): void {
     model.session.kernelChanged.connect(() => { kernelChanged(model); });
+    // Update the kernel data now.
+    kernelChanged(model);
   }
 
   /**

--- a/src/notebook/model.ts
+++ b/src/notebook/model.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+'use strict';
+
+import * as CodeMirror
+  from 'codemirror';
 
 import {
   INotebookSession, IExecuteReply,  IContentsManager, IKernel
@@ -64,6 +70,8 @@ import {
 export
 type NotebookMode = 'command' | 'edit';
 
+import './codemirror-ipython';
+import './codemirror-ipythongfm';
 
 /**
  * The definition of a model object for a notebook widget.
@@ -646,18 +654,26 @@ namespace NotebookModelPrivate {
       return session.kernel.kernelInfo();
     }).then(info => {
       metadata.language_info = info.language_info;
-      // We need to use codemirror mode first.
+      // Use the codemirror mode if given since some kernels rely on it.
       let mode = metadata.language_info.codemirror_mode;
       let mime = '';
       if (mode) {
         if (typeof mode === 'string') {
-          mode = CodeMirror.findModeByName(mode as string);
+          if (CodeMirror.modes.hasOwnProperty(mode)) {
+            mode = CodeMirror.modes[mode];
+          } else {
+            mode = CodeMirror.findModeByName(mode as string);
+          }
         } else if (mode.mime) {
           // Do nothing.
         } else if (mode.name) {
-          mode = CodeMirror.findModeByName(mode.name);
+          if (CodeMirror.modes.hasOwnProperty(mode.name)) {
+            mode = CodeMirror.modes[mode.name];
+          } else {
+            mode = CodeMirror.findModeByName(mode as string);
+          }
         }
-        mime = mode.mime;
+        if (mode) mime = mode.mime;
       } else {
         mime = info.language_info.mimetype;
       }

--- a/src/notebook/model.ts
+++ b/src/notebook/model.ts
@@ -646,15 +646,20 @@ namespace NotebookModelPrivate {
       return session.kernel.kernelInfo();
     }).then(info => {
       metadata.language_info = info.language_info;
-      let mime = info.language_info.mimetype;
-      if (!mime) {
-        let mode = info.language_info.codemirror_mode;
+      // We need to use codemirror mode first.
+      let mode = metadata.language_info.codemirror_mode;
+      let mime = '';
+      if (mode) {
         if (typeof mode === 'string') {
-          let info = CodeMirror.findModeByName(mode as string);
-          mime = info.mime;
-        } else if ((mode as CodeMirror.modespec).mime) {
-          mime = (mode as CodeMirror.modespec).mime;
+          mode = CodeMirror.findModeByName(mode as string);
+        } else if (mode.mime) {
+          // Do nothing.
+        } else if (mode.name) {
+          mode = CodeMirror.findModeByName(mode.name);
         }
+        mime = mode.mime;
+      } else {
+        mime = info.language_info.mimetype;
       }
       if (mime) {
         model.defaultMimetype = mime;

--- a/src/notebook/selector.ts
+++ b/src/notebook/selector.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+'use strict';
+
+import {
+  IKernelSpecId
+} from 'jupyter-js-services';
+
+import {
+  showDialog
+} from 'jupyter-js-ui/lib/dialog';
+
+import {
+  INotebookModel
+} from './model';
+
+
+/**
+ * Present a dialog asking the user to select a kernel.
+ */
+export 
+function selectKernel(host: HTMLElement, model: INotebookModel, specs: IKernelSpecId[]): Promise<void> {
+  let selector = document.createElement('select');
+  for (let spec of specs) {
+    let option = document.createElement('option');
+    option.value = spec.name;
+    option.text = spec.spec.display_name;
+  }
+  return showDialog({
+    title: 'Select Kernel',
+    host,
+    body: selector
+  }).then(result => {
+    if (result.text === 'OK') {
+      return model.session.changeKernel(selector.value);
+    }
+  }).then(() => { return void 0; });
+}

--- a/src/notebook/selector.ts
+++ b/src/notebook/selector.ts
@@ -3,7 +3,7 @@
 'use strict';
 
 import {
-  IKernelSpecIds
+  IKernelSpecIds, IKernel
 } from 'jupyter-js-services';
 
 import {
@@ -23,7 +23,7 @@ import {
  * Present a dialog asking the user to select a kernel.
  */
 export 
-function selectKernel(host: HTMLElement, model: INotebookModel, specs: IKernelSpecIds): Promise<void> {
+function selectKernel(host: HTMLElement, model: INotebookModel, specs: IKernelSpecIds): Promise<IKernel> {
   let selector = document.createElement('select');
   let options: HTMLOptionElement[] = [];
   for (let name in specs.kernelspecs) {
@@ -53,26 +53,6 @@ function selectKernel(host: HTMLElement, model: INotebookModel, specs: IKernelSp
         return model.session.changeKernel(selector.value);
       }
     }
-  }).then(kernel => {
-    return kernel.kernelInfo();
-  }).then(info => {
-    let mime = info.language_info.mimetype;
-    if (!mime) {
-      let mode = info.language_info.codemirror_mode;
-      if (mode) {
-        let info = CodeMirror.findModeByName(mode as string);
-        mime = info.mime;
-      }
-    }
-    if (mime) {
-      model.defaultMimetype = mime;
-      let cells = model.cells;
-      for (let i = 0; i < cells.length; i++) {
-        let cell = cells.get(i);
-        if (isCodeCellModel(cell)) {
-          cell.input.textEditor.mimetype = mime;
-        }
-      }
-    }
+    return model.session.kernel;
   });
 }

--- a/src/notebook/selector.ts
+++ b/src/notebook/selector.ts
@@ -3,12 +3,16 @@
 'use strict';
 
 import {
-  IKernelSpecId
+  IKernelSpecIds
 } from 'jupyter-js-services';
 
 import {
   showDialog
 } from 'jupyter-js-ui/lib/dialog';
+
+import {
+  isCodeCellModel
+} from '../cells';
 
 import {
   INotebookModel
@@ -19,12 +23,25 @@ import {
  * Present a dialog asking the user to select a kernel.
  */
 export 
-function selectKernel(host: HTMLElement, model: INotebookModel, specs: IKernelSpecId[]): Promise<void> {
+function selectKernel(host: HTMLElement, model: INotebookModel, specs: IKernelSpecIds): Promise<void> {
   let selector = document.createElement('select');
-  for (let spec of specs) {
+  let options: HTMLOptionElement[] = [];
+  for (let name in specs.kernelspecs) {
     let option = document.createElement('option');
-    option.value = spec.name;
-    option.text = spec.spec.display_name;
+    option.value = name;
+    option.text = specs.kernelspecs[name].spec.display_name;
+    options.push(option);
+  }
+  options.sort((a, b) => { return a.text.localeCompare(b.text); });
+  for (let option of options) {
+    selector.appendChild(option);
+  }
+  if (model.session) {
+    selector.value = model.session.kernel.name;
+  } else if (model.metadata && model.metadata.kernelspec) {
+    selector.value = model.metadata.kernelspec.name;
+  } else {
+    selector.value = specs.kernelspecs[specs.default].spec.display_name;
   }
   return showDialog({
     title: 'Select Kernel',
@@ -32,7 +49,30 @@ function selectKernel(host: HTMLElement, model: INotebookModel, specs: IKernelSp
     body: selector
   }).then(result => {
     if (result.text === 'OK') {
-      return model.session.changeKernel(selector.value);
+      if (model.session.kernel.name !== selector.value) {
+        return model.session.changeKernel(selector.value);
+      }
     }
-  }).then(() => { return void 0; });
+  }).then(kernel => {
+    return kernel.kernelInfo();
+  }).then(info => {
+    let mime = info.language_info.mimetype;
+    if (!mime) {
+      let mode = info.language_info.codemirror_mode;
+      if (mode) {
+        let info = CodeMirror.findModeByName(mode as string);
+        mime = info.mime;
+      }
+    }
+    if (mime) {
+      model.defaultMimetype = mime;
+      let cells = model.cells;
+      for (let i = 0; i < cells.length; i++) {
+        let cell = cells.get(i);
+        if (isCodeCellModel(cell)) {
+          cell.input.textEditor.mimetype = mime;
+        }
+      }
+    }
+  });
 }

--- a/src/notebook/widget.ts
+++ b/src/notebook/widget.ts
@@ -53,9 +53,6 @@ import {
   INotebookMetadata
 } from './nbformat';
 
-import './codemirror-ipython';
-import './codemirror-ipythongfm';
-
 
 /**
  * The class name added to notebook widgets.

--- a/src/notebook/widget.ts
+++ b/src/notebook/widget.ts
@@ -3,7 +3,7 @@
 'use strict';
 
 import {
-  INotebookSession, IKernel, KernelStatus
+  KernelStatus
 } from 'jupyter-js-services';
 
 import {
@@ -820,17 +820,6 @@ class NotebookToolbar extends Widget {
     } else {
       node.classList.add(TOOLBAR_BUSY);
     }
-    session.kernelChanged.connect(this.handleKernel, this);
-    this.handleKernel(session, session.kernel);
-  }
-
-  /**
-   * Handle a change to the kernel.
-   */
-  protected handleKernel(session: INotebookSession, kernel: IKernel): void {
-    kernel.getKernelSpec().then(spec => {
-      this.kernelNameNode.textContent = spec.display_name;
-    });
   }
 
   /**


### PR DESCRIPTION
Clean up metadata handling as well.
Attempts to extract a proper mimetype from a codemirror mode if given, but does not propagate the mode itself.
Relies on https://github.com/jupyter/notebook/pull/1206 and https://github.com/jupyter/jupyter-js-services/pull/110.

![jupterlab-kernel-selector](https://cloud.githubusercontent.com/assets/2096628/13753732/38bb55e4-e9e2-11e5-8c12-4618070111b1.gif)
