### PR TITLE
Clean up mode handling

### DIFF
--- a/src/cells/model.ts
+++ b/src/cells/model.ts
@@ -45,16 +45,6 @@ import {
 export
 type ScrollSetting = boolean | 'auto';
 
-/**
- * The class name added to a cell in edit mode.
- */
-const EDIT_CLASS = 'jp-mod-editMode';
-
-/**
- * The class name added to a cell in command mode.
- */
-const COMMAND_CLASS = 'jp-mod-commandMode';
-
 
 /**
  * The definition of a model object for a base cell.

--- a/src/cells/model.ts
+++ b/src/cells/model.ts
@@ -40,16 +40,21 @@ import {
 
 
 /**
- * The interactivity modes for a cell.
- */
-export
-type CellMode = 'command' | 'edit';
-
-/**
  * The scrolled setting of a cell.
  */
 export
 type ScrollSetting = boolean | 'auto';
+
+/**
+ * The class name added to a cell in edit mode.
+ */
+const EDIT_CLASS = 'jp-mod-editMode';
+
+/**
+ * The class name added to a cell in command mode.
+ */
+const COMMAND_CLASS = 'jp-mod-commandMode';
+
 
 /**
  * The definition of a model object for a base cell.
@@ -80,11 +85,6 @@ interface IBaseCellModel extends IDisposable {
    * Whether the cell is the active cell in the notebook.
    */
   active: boolean;
-
-  /**
-   * The mode of the cell.
-   */
-  mode: CellMode;
 
   /**
    * The input area of the cell.
@@ -184,7 +184,6 @@ class BaseCellModel implements IBaseCellModel {
    */
   constructor(input: IInputAreaModel) {
     this._input = input;
-    input.textEditor.stateChanged.connect(this.onEditorChanged, this);
   }
 
   /**
@@ -202,23 +201,6 @@ class BaseCellModel implements IBaseCellModel {
   }
   set active(value: boolean) {
     CellModelPrivate.activeProperty.set(this, value);
-  }
-
-  /**
-   * The mode of the cell.
-   *
-   * #### Notes
-   * This is a delegate to the focused state of the input's editor.
-   */
-  get mode(): CellMode {
-    if (this.input.textEditor.focused) {
-      return 'edit';
-    } else {
-      return 'command';
-    }
-  }
-  set mode(value: CellMode) {
-    this.input.textEditor.focused = value === 'edit';
   }
 
   /**
@@ -250,7 +232,6 @@ class BaseCellModel implements IBaseCellModel {
   set readOnly(value: boolean) {
     this.input.readOnly = value;
   }
-
 
   /**
    * The trusted state of the cell.
@@ -311,28 +292,6 @@ class BaseCellModel implements IBaseCellModel {
    * The type of cell.
    */
   type: CellType;
-
-  /**
-   * Handle changes to the editor model.
-   */
-  private onEditorChanged(editor: IEditorModel, args: IChangedArgs<any>): void {
-    // Handle changes to the focused state of the editor.
-    if (args.name === 'focused') {
-      if (args.newValue) {
-        this.stateChanged.emit({
-          name: 'mode',
-          newValue: 'edit',
-          oldValue: 'command'
-        });
-      } else {
-        this.stateChanged.emit({
-          name: 'mode',
-          newValue: 'command',
-          oldValue: 'edit'
-        });
-      }
-    }
-  }
 
   private _input: IInputAreaModel = null;
 }

--- a/src/cells/model.ts
+++ b/src/cells/model.ts
@@ -45,12 +45,6 @@ import {
 export
 type ScrollSetting = boolean | 'auto';
 
-/**
- * The interactivity modes for a cell.
- */
-export
-type CellMode = 'command' | 'edit';
-
 
 /**
  * The definition of a model object for a base cell.
@@ -81,11 +75,6 @@ interface IBaseCellModel extends IDisposable {
    * Whether the cell is the active cell in the notebook.
    */
   active: boolean;
-
-  /**
-   * The interactivity mode of the cell.
-   */
-  mode: CellMode;
 
   /**
    * The input area of the cell.
@@ -192,16 +181,6 @@ class BaseCellModel implements IBaseCellModel {
    */
   get stateChanged(): ISignal<IBaseCellModel, IChangedArgs<any>> {
     return CellModelPrivate.stateChangedSignal.bind(this);
-  }
-
-  /**
-   * The mode of the cell.
-   */
-  get mode(): CellMode {
-    return CellModelPrivate.modeProperty.get(this);
-  }
-  set mode(value: CellMode) {
-    CellModelPrivate.modeProperty.set(this, value);
   }
 
   /**
@@ -456,15 +435,6 @@ namespace CellModelPrivate {
    */
   export
   const stateChangedSignal = new Signal<IBaseCellModel, IChangedArgs<any>>();
-
- /**
-  * A property descriptor for the cell mode.
-  */
-  export
-  const modeProperty = new Property<IBaseCellModel, CellMode>({
-    name: 'mode',
-    notify: stateChangedSignal,
-  });
 
   /**
    * A property descriptor for the selected state of the cell.

--- a/src/cells/model.ts
+++ b/src/cells/model.ts
@@ -45,6 +45,12 @@ import {
 export
 type ScrollSetting = boolean | 'auto';
 
+/**
+ * The interactivity modes for a cell.
+ */
+export
+type CellMode = 'command' | 'edit';
+
 
 /**
  * The definition of a model object for a base cell.
@@ -75,6 +81,11 @@ interface IBaseCellModel extends IDisposable {
    * Whether the cell is the active cell in the notebook.
    */
   active: boolean;
+
+  /**
+   * The interactivity mode of the cell.
+   */
+  mode: CellMode;
 
   /**
    * The input area of the cell.
@@ -181,6 +192,16 @@ class BaseCellModel implements IBaseCellModel {
    */
   get stateChanged(): ISignal<IBaseCellModel, IChangedArgs<any>> {
     return CellModelPrivate.stateChangedSignal.bind(this);
+  }
+
+  /**
+   * The mode of the cell.
+   */
+  get mode(): CellMode {
+    return CellModelPrivate.modeProperty.get(this);
+  }
+  set mode(value: CellMode) {
+    CellModelPrivate.modeProperty.set(this, value);
   }
 
   /**
@@ -435,6 +456,15 @@ namespace CellModelPrivate {
    */
   export
   const stateChangedSignal = new Signal<IBaseCellModel, IChangedArgs<any>>();
+
+ /**
+  * A property descriptor for the cell mode.
+  */
+  export
+  const modeProperty = new Property<IBaseCellModel, CellMode>({
+    name: 'mode',
+    notify: stateChangedSignal,
+  });
 
   /**
    * A property descriptor for the selected state of the cell.

--- a/src/cells/widget.ts
+++ b/src/cells/widget.ts
@@ -83,16 +83,6 @@ const RAW_CELL_CLASS = 'jp-RawCell';
 const RENDERED_CLASS = 'jp-mod-rendered';
 
 /**
- * The class name added to a cell in edit mode.
- */
-const EDIT_CLASS = 'jp-mod-editMode';
-
-/**
- * The class name added to a cell in command mode.
- */
-const COMMAND_CLASS = 'jp-mod-commandMode';
-
-/**
  * The text applied to an empty markdown cell.
  */
 const DEFAULT_MARKDOWN_TEXT = 'Type Markdown and LaTeX: $ α^2 $'
@@ -173,13 +163,6 @@ class BaseCellWidget extends Widget {
       this.addClass(SELECTED_CLASS);
     } else {
       this.removeClass(SELECTED_CLASS);
-    }
-    if (this.model.mode === 'edit') {
-      this.addClass(EDIT_CLASS);
-      this.removeClass(COMMAND_CLASS);
-    } else {
-      this.addClass(COMMAND_CLASS)
-      this.removeClass(EDIT_CLASS);
     }
   }
 

--- a/src/cells/widget.ts
+++ b/src/cells/widget.ts
@@ -206,7 +206,7 @@ class BaseCellWidget extends Widget {
   }
 
   /**
-   * Handle `after-attach` messages to the cell.
+   * Handle `after-attach` messages sent to the cell.
    */
   protected onAfterAttach(msg: Message): void {
     this.input.editor.node.addEventListener('focus', this, true);
@@ -214,6 +214,9 @@ class BaseCellWidget extends Widget {
     this.update();
   }
 
+  /**
+   * Handle `before-detach` messages sent to the cell.
+   */
   protected onBeforeDetach(msg: Message): void {
     this.input.editor.node.removeEventListener('focus', this, true);
     this.input.editor.node.removeEventListener('blur', this, true);

--- a/src/cells/widget.ts
+++ b/src/cells/widget.ts
@@ -18,6 +18,10 @@ import {
 } from 'phosphor-properties';
 
 import {
+  ISignal, Signal
+} from 'phosphor-signaling';
+
+import {
   Widget
 } from 'phosphor-widget';
 
@@ -83,16 +87,6 @@ const RAW_CELL_CLASS = 'jp-RawCell';
 const RENDERED_CLASS = 'jp-mod-rendered';
 
 /**
- * The class name added to a cell in edit mode.
- */
-const EDIT_CLASS = 'jp-mod-editMode';
-
-/**
- * The class name added to a cell in command mode.
- */
-const COMMAND_CLASS = 'jp-mod-commandMode';
-
-/**
  * The text applied to an empty markdown cell.
  */
 const DEFAULT_MARKDOWN_TEXT = 'Type Markdown and LaTeX: $ α^2 $'
@@ -124,6 +118,13 @@ class BaseCellWidget extends Widget {
     this.layout = new PanelLayout();
     (this.layout as PanelLayout).addChild(this._input);
     model.stateChanged.connect(this.onModelChanged, this);
+  }
+
+  /**
+   * A signal emitted when the focus state of the cell's editor changes.
+   */
+  get editorFocusChanged(): ISignal<BaseCellWidget, boolean> {
+    return Private.editorFocusChangedSignal.bind(this);
   }
 
   /**
@@ -165,10 +166,10 @@ class BaseCellWidget extends Widget {
   handleEvent(event: Event) {
     switch (event.type) {
     case 'blur':
-      this.model.mode = 'command';
+      this.editorFocusChanged.emit(false);
       break;
     case 'focus':
-      this.model.mode = 'edit';
+      this.editorFocusChanged.emit(true);
       this.input.editor.focus();
       break;
     }
@@ -188,13 +189,6 @@ class BaseCellWidget extends Widget {
       this.addClass(SELECTED_CLASS);
     } else {
       this.removeClass(SELECTED_CLASS);
-    }
-    if (this.model.mode === 'edit') {
-      this.addClass(EDIT_CLASS);
-      this.removeClass(COMMAND_CLASS);
-    } else {
-      this.addClass(COMMAND_CLASS);
-      this.removeClass(EDIT_CLASS);
     }
   }
 
@@ -357,4 +351,16 @@ class RawCellWidget extends BaseCellWidget {
     super(model);
     this.addClass(RAW_CELL_CLASS);
   }
+}
+
+
+/**
+ * A namespace for cell widget private data.
+ */
+namespace Private {
+  /**
+   * A signal emitted when the focus state of the cell's editor changes.
+   */
+  export
+  const editorFocusChangedSignal = new Signal<BaseCellWidget, boolean>();
 }

--- a/src/cells/widget.ts
+++ b/src/cells/widget.ts
@@ -83,6 +83,16 @@ const RAW_CELL_CLASS = 'jp-RawCell';
 const RENDERED_CLASS = 'jp-mod-rendered';
 
 /**
+ * The class name added to a cell in edit mode.
+ */
+const EDIT_CLASS = 'jp-mod-editMode';
+
+/**
+ * The class name added to a cell in command mode.
+ */
+const COMMAND_CLASS = 'jp-mod-commandMode';
+
+/**
  * The text applied to an empty markdown cell.
  */
 const DEFAULT_MARKDOWN_TEXT = 'Type Markdown and LaTeX: $ α^2 $'
@@ -150,6 +160,21 @@ class BaseCellWidget extends Widget {
   }
 
   /**
+   * Handle DOM events for the widget.
+   */
+  handleEvent(event: Event) {
+    switch (event.type) {
+    case 'blur':
+      this.model.mode = 'command';
+      break;
+    case 'focus':
+      this.model.mode = 'edit';
+      this.input.editor.focus();
+      break;
+    }
+  }
+
+  /**
    * Handle `update_request` messages.
    */
   protected onUpdateRequest(message: Message): void {
@@ -164,6 +189,13 @@ class BaseCellWidget extends Widget {
     } else {
       this.removeClass(SELECTED_CLASS);
     }
+    if (this.model.mode === 'edit') {
+      this.addClass(EDIT_CLASS);
+      this.removeClass(COMMAND_CLASS);
+    } else {
+      this.addClass(COMMAND_CLASS);
+      this.removeClass(EDIT_CLASS);
+    }
   }
 
   /**
@@ -177,7 +209,14 @@ class BaseCellWidget extends Widget {
    * Handle `after-attach` messages to the cell.
    */
   protected onAfterAttach(msg: Message): void {
+    this.input.editor.node.addEventListener('focus', this, true);
+    this.input.editor.node.addEventListener('blur', this, true);
     this.update();
+  }
+
+  protected onBeforeDetach(msg: Message): void {
+    this.input.editor.node.removeEventListener('focus', this, true);
+    this.input.editor.node.removeEventListener('blur', this, true);
   }
 
   private _input: InputAreaWidget = null;

--- a/src/editor/model.ts
+++ b/src/editor/model.ts
@@ -44,11 +44,6 @@ interface IEditorModel extends IDisposable {
   filename: string;
 
   /**
-   * Whether the editor is focused.
-   */
-  focused: boolean;
-
-  /**
    * Whether the text editor has a fixed maximum height.
    *
    * #### Notes
@@ -189,16 +184,6 @@ class EditorModel implements IEditorModel {
   }
 
   /**
-   * Whether the editor is focused for editing.
-   */
-  get focused(): boolean {
-    return EditorModelPrivate.focusedProperty.get(this);
-  }
-  set focused(value: boolean) {
-    EditorModelPrivate.focusedProperty.set(this, value);
-  }
-
-  /**
    * The tabSize number for the editor model.
    */
   get tabSize(): number {
@@ -300,16 +285,6 @@ namespace EditorModelPrivate {
   export
   const readOnlyProperty = new Property<EditorModel, boolean>({
     name: 'readOnly',
-    value: false,
-    notify: stateChangedSignal
-  });
-
-  /**
-   * The property descriptor for the editor focused property.
-   */
-  export
-  const focusedProperty = new Property<EditorModel, boolean>({
-    name: 'focused',
     value: false,
     notify: stateChangedSignal
   });

--- a/src/editor/widget.ts
+++ b/src/editor/widget.ts
@@ -57,7 +57,13 @@ interface IEditorWidget extends Widget {
    * The model for the editor widget.
    */
   model: IEditorModel;
+
+  /**
+   * Focus the editor.
+   */
+  focus(): void;
 }
+
 
 /**
  * A widget which hosts a CodeMirror editor.
@@ -84,12 +90,6 @@ class CodeMirrorWidget extends Widget implements IEditorWidget {
         this._model.text = instance.getValue();
       }
     });
-    this._editor.on('focus', () => {
-      this._model.focused = true;
-    });
-    this._editor.on('blur', () => {
-      this._model.focused = false;
-    });
     model.stateChanged.connect(this.onModelStateChanged, this);
   }
 
@@ -101,6 +101,13 @@ class CodeMirrorWidget extends Widget implements IEditorWidget {
    */
   get model(): IEditorModel {
     return this._model;
+  }
+
+  /**
+   * Focus the editor.
+   */
+  focus(): void {
+    this._editor.focus();
   }
 
   /**
@@ -265,10 +272,6 @@ class CodeMirrorWidget extends Widget implements IEditorWidget {
     case 'tabSize':
       this.updateTabSize(args.newValue as number);
       break;
-    case 'focused':
-      if (args.newValue) {
-        this._editor.focus();
-      }
     }
   }
 

--- a/src/input-area/widget.ts
+++ b/src/input-area/widget.ts
@@ -119,7 +119,6 @@ class InputAreaWidget extends Widget {
     return this._prompt;
   }
 
-
   /**
    * Dispose of the resources held by the widget.
    */

--- a/src/notebook/model.ts
+++ b/src/notebook/model.ts
@@ -40,7 +40,7 @@ import {
   ICodeCellModel, CodeCellModel,
   IMarkdownCellModel, MarkdownCellModel,
   IRawCellModel, isCodeCellModel, isMarkdownCellModel,
-  RawCellModel, isRawCellModel, CellMode
+  RawCellModel, isRawCellModel
 } from '../cells';
 
 import {
@@ -56,6 +56,13 @@ import {
 import {
   serialize
 } from './serialize';
+
+
+/**
+ * The interactivity modes for the notebook.
+ */
+export
+type NotebookMode = 'command' | 'edit';
 
 
 /**
@@ -75,6 +82,11 @@ interface INotebookModel extends IDisposable {
    * This can be considered the default language of the notebook.
    */
   defaultMimetype: string;
+
+  /**
+   * The interactivity mode of the notebook.
+   */
+  mode: NotebookMode;
 
   /**
    * Whether the notebook has unsaved changes.
@@ -273,6 +285,16 @@ class NotebookModel implements INotebookModel {
   }
 
   /**
+   * The mode of the notebook.
+   */
+  get mode(): NotebookMode {
+    return NotebookModelPrivate.modeProperty.get(this);
+  }
+  set mode(value: NotebookMode) {
+    NotebookModelPrivate.modeProperty.set(this, value);
+  }
+
+  /**
    * Whether the notebook has unsaved changes.
    */
   get dirty(): boolean {
@@ -413,7 +435,7 @@ class NotebookModel implements INotebookModel {
     if (this.activeCellIndex === this.cells.length - 1) {
       let cell = this.createCodeCell();
       this.cells.add(cell);
-      cell.mode = 'edit';  // This already sets the new index.
+      this.mode = 'edit';  // This already sets the new index.
     } else {
       this.activeCellIndex += 1;
     }
@@ -597,7 +619,16 @@ namespace NotebookModelPrivate {
   });
 
  /**
-  * A property descriptor for the dirty state
+  * A property descriptor for the notebook mode.
+  */
+  export
+  const modeProperty = new Property<NotebookModel, NotebookMode>({
+    name: 'mode',
+    notify: stateChangedSignal,
+  });
+
+ /**
+  * A property descriptor for the dirty state of the notebook.
   */
   export
   const dirtyProperty = new Property<NotebookModel, boolean>({

--- a/src/notebook/model.ts
+++ b/src/notebook/model.ts
@@ -59,6 +59,13 @@ import {
 
 
 /**
+ * The interactivity modes for a cell.
+ */
+export
+type NotebookMode = 'command' | 'edit';
+
+
+/**
  * The definition of a model object for a notebook widget.
  */
 export
@@ -75,6 +82,11 @@ interface INotebookModel extends IDisposable {
    * This can be considered the default language of the notebook.
    */
   defaultMimetype: string;
+
+  /**
+   * The interactivity mode of the active cell.
+   */
+  mode: NotebookMode;
 
   /**
    * Whether the notebook has unsaved changes.
@@ -205,6 +217,16 @@ class NotebookModel implements INotebookModel {
    */
   get cells(): IObservableList<ICellModel> {
     return this._cells;
+  }
+
+  /**
+   * The mode of the cell.
+   */
+  get mode(): NotebookMode {
+    return NotebookModelPrivate.modeProperty.get(this);
+  }
+  set mode(value: NotebookMode) {
+    NotebookModelPrivate.modeProperty.set(this, value);
   }
 
   /**
@@ -413,7 +435,7 @@ class NotebookModel implements INotebookModel {
     if (this.activeCellIndex === this.cells.length - 1) {
       let cell = this.createCodeCell();
       this.cells.add(cell);
-      cell.mode = 'edit';  // This already sets the new index.
+      this.mode = 'edit';  // This already sets the new index.
     } else {
       this.activeCellIndex += 1;
     }
@@ -549,6 +571,15 @@ namespace NotebookModelPrivate {
    */
   export
   const stateChangedSignal = new Signal<INotebookModel, IChangedArgs<any>>();
+
+ /**
+  * A property descriptor for the active cell interactivity mode.
+  */
+  export
+  const modeProperty = new Property<INotebookModel, NotebookMode>({
+    name: 'mode',
+    notify: stateChangedSignal,
+  });
 
   /**
   * A property descriptor which holds the default mimetype for new code cells.

--- a/src/notebook/model.ts
+++ b/src/notebook/model.ts
@@ -59,13 +59,6 @@ import {
 
 
 /**
- * The interactivity modes for the notebook.
- */
-export
-type NotebookMode = 'command' | 'edit';
-
-
-/**
  * The definition of a model object for a notebook widget.
  */
 export
@@ -82,11 +75,6 @@ interface INotebookModel extends IDisposable {
    * This can be considered the default language of the notebook.
    */
   defaultMimetype: string;
-
-  /**
-   * The interactivity mode of the notebook.
-   */
-  mode: NotebookMode;
 
   /**
    * Whether the notebook has unsaved changes.
@@ -285,16 +273,6 @@ class NotebookModel implements INotebookModel {
   }
 
   /**
-   * The mode of the notebook.
-   */
-  get mode(): NotebookMode {
-    return NotebookModelPrivate.modeProperty.get(this);
-  }
-  set mode(value: NotebookMode) {
-    NotebookModelPrivate.modeProperty.set(this, value);
-  }
-
-  /**
    * Whether the notebook has unsaved changes.
    */
   get dirty(): boolean {
@@ -435,7 +413,7 @@ class NotebookModel implements INotebookModel {
     if (this.activeCellIndex === this.cells.length - 1) {
       let cell = this.createCodeCell();
       this.cells.add(cell);
-      this.mode = 'edit';  // This already sets the new index.
+      cell.mode = 'edit';  // This already sets the new index.
     } else {
       this.activeCellIndex += 1;
     }
@@ -615,15 +593,6 @@ namespace NotebookModelPrivate {
   export
   const activeCellIndexProperty = new Property<NotebookModel, number>({
     name: 'activeCellIndex',
-    notify: stateChangedSignal,
-  });
-
- /**
-  * A property descriptor for the notebook mode.
-  */
-  export
-  const modeProperty = new Property<NotebookModel, NotebookMode>({
-    name: 'mode',
     notify: stateChangedSignal,
   });
 

--- a/src/notebook/widget.ts
+++ b/src/notebook/widget.ts
@@ -407,9 +407,10 @@ class NotebookWidget extends Widget {
       // Activate the appropriate cell.
       let layout = this._notebook.layout as PanelLayout;
       for (let i = 0; i < layout.childCount(); i++) {
-        let widget = layout.childAt(i);
+        let widget = layout.childAt(i) as BaseCellWidget;
         if (widget.node.contains(event.target as HTMLElement)) {
           this.model.activeCellIndex = i;
+          widget.input.editor.focus();
           break;
         }
       }

--- a/src/notebook/widget.ts
+++ b/src/notebook/widget.ts
@@ -35,7 +35,7 @@ import {
 } from 'phosphor-panel';
 
 import {
-  ICellModel,
+  ICellModel, BaseCellWidget,
   CodeCellWidget, MarkdownCellWidget,
   CodeCellModel, MarkdownCellModel, isMarkdownCellModel,
   RawCellModel, RawCellWidget
@@ -154,6 +154,16 @@ const TOOLBAR_PRESSED = 'jp-mod-pressed';
 const TOOLBAR_BUSY = 'jp-mod-busy';
 
 /**
+ * The class name added to a cell in edit mode.
+ */
+const EDIT_CLASS = 'jp-mod-editMode';
+
+/**
+ * The class name added to a cell in command mode.
+ */
+const COMMAND_CLASS = 'jp-mod-commandMode';
+
+/**
  * The maximum size of the delete stack.
  */
 const DELETE_STACK_SIZE = 10;
@@ -167,8 +177,8 @@ class NotebookWidget extends Widget {
   /**
    * Create a new cell widget given a cell model.
    */
-  static createCell(cell: ICellModel): Widget {
-    let widget: Widget;
+  static createCell(cell: ICellModel): BaseCellWidget {
+    let widget: BaseCellWidget;
     switch(cell.type) {
     case 'code':
       widget = new CodeCellWidget(cell as CodeCellModel);
@@ -182,7 +192,7 @@ class NotebookWidget extends Widget {
     default:
       // If there are any issues, just return a blank placeholder
       // widget so the lists stay in sync.
-      widget = new Widget();
+      widget = new BaseCellWidget(cell);
     }
     widget.addClass(NB_CELL_CLASS);
     return widget;
@@ -222,6 +232,7 @@ class NotebookWidget extends Widget {
       cellsLayout.addChild(factory(model.cells.get(i)));
     }
     model.cells.changed.connect(this.onCellsChanged, this);
+    model.stateChanged.connect(this.onModelChanged, this);
   }
 
   /**
@@ -384,6 +395,48 @@ class NotebookWidget extends Widget {
   }
 
   /**
+   * Handle DOM events for the widget.
+   */
+  handleEvent(event: Event) {
+    switch (event.type) {
+    case 'blur':
+      this.model.mode = 'command';
+      break;
+    case 'focus':
+      this.model.mode = 'edit';
+      // Activate the appropriate cell.
+      let layout = this._notebook.layout as PanelLayout;
+      for (let i = 0; i < layout.childCount(); i++) {
+        let widget = layout.childAt(i);
+        if (widget.node.contains(event.target as HTMLElement)) {
+          this.model.activeCellIndex = i;
+          break;
+        }
+      }
+      break;
+    }
+  }
+
+  /**
+   * Initialize a cell widget.
+   */
+  protected initCell(cell: BaseCellWidget): void {
+    cell.input.editor.node.addEventListener('focus', this, true);
+    cell.input.editor.node.addEventListener('blur', this, true);
+  }
+
+  /**
+   * Dispose of a cell widget.
+   */
+  protected disposeCell(cell: BaseCellWidget): void {
+    cell.input.editor.node.removeEventListener('focus', this, true);
+    cell.input.editor.node.removeEventListener('blur', this, true);
+    let layout = this.layout as PanelLayout;
+    layout.removeChild(cell);
+    cell.dispose();
+  }
+
+  /**
    * Handle a change cells event.  This function must be on this class
    * because it uses the static [createCell] method.
    */
@@ -391,36 +444,73 @@ class NotebookWidget extends Widget {
     let layout = this._notebook.layout as PanelLayout;
     let constructor = this.constructor as typeof NotebookWidget;
     let factory = constructor.createCell;
-    let widget: Widget;
+    let widget: BaseCellWidget;
     switch(args.type) {
     case ListChangeType.Add:
-      layout.insertChild(args.newIndex, factory(args.newValue as ICellModel));
+      widget = factory(args.newValue as ICellModel);
+      layout.insertChild(args.newIndex, widget);
+      this.initCell(widget);
       break;
     case ListChangeType.Move:
       layout.insertChild(args.newIndex, layout.childAt(args.oldIndex));
       break;
     case ListChangeType.Remove:
-      widget = layout.childAt(args.oldIndex);
-      layout.removeChild(widget);
-      widget.dispose();
+      widget = layout.childAt(args.oldIndex) as BaseCellWidget;
+      this.disposeCell(widget);
       break;
     case ListChangeType.Replace:
       let oldValues = args.oldValue as ICellModel[];
       for (let i = args.oldIndex; i < oldValues.length; i++) {
-        widget = layout.childAt(args.oldIndex);
-        layout.removeChild(widget);
-        widget.dispose();
+        widget = layout.childAt(args.oldIndex) as BaseCellWidget;
+        this.disposeCell(widget);
       }
       let newValues = args.newValue as ICellModel[];
       for (let i = newValues.length; i < 0; i--) {
-        layout.insertChild(args.newIndex, factory(newValues[i]));
+        widget = factory(newValues[i])
+        layout.insertChild(args.newIndex, widget);
+        this.initCell(widget);
       }
       break;
     case ListChangeType.Set:
-      widget = layout.childAt(args.newIndex);
-      layout.removeChild(widget);
-      widget.dispose();
-      layout.insertChild(args.newIndex, factory(args.newValue as ICellModel));
+      widget = layout.childAt(args.newIndex) as BaseCellWidget;
+      this.disposeCell(widget);
+      widget = factory(args.newValue as ICellModel);
+      layout.insertChild(args.newIndex, widget);
+      this.initCell(widget);
+      break;
+    }
+    this.update();
+  }
+
+  /**
+   * Handle `update-request` messages sent to the widget.
+   */
+  protected onUpdateRequest(msg: Message): void {
+    // Set the appropriate classes on the cells.
+    let model = this.model;
+    let cells = this.model.cells;
+    let mode = model.mode;
+    let layout = this._notebook.layout as PanelLayout;
+    for (let i = 0; i < cells.length; i++) {
+      let cell = cells.get(i);
+      let widget = layout.childAt(i);
+      if (mode === 'edit') {
+        widget.addClass(EDIT_CLASS);
+        widget.removeClass(COMMAND_CLASS);
+      } else {
+        widget.addClass(COMMAND_CLASS);
+        widget.removeClass(EDIT_CLASS);
+      }
+    }
+  }
+
+  /**
+   * Handle changes to the notebook model.
+   */
+  protected onModelChanged(model: INotebookModel, args: IChangedArgs<any>): void {
+    switch (args.name) {
+    case 'mode':
+      this.update();
       break;
     }
   }
@@ -574,7 +664,7 @@ class NotebookCells extends Widget {
     let cell = model.cells.get(i);
     if (isMarkdownCellModel(cell) && cell.rendered) {
       cell.rendered = false;
-      cell.mode = 'edit';
+      model.mode = 'edit';
     }
   }
 

--- a/src/notebook/widget.ts
+++ b/src/notebook/widget.ts
@@ -35,7 +35,7 @@ import {
 } from 'phosphor-panel';
 
 import {
-  ICellModel,
+  ICellModel, BaseCellWidget,
   CodeCellWidget, MarkdownCellWidget,
   CodeCellModel, MarkdownCellModel, isMarkdownCellModel,
   RawCellModel, RawCellWidget
@@ -154,6 +154,16 @@ const TOOLBAR_PRESSED = 'jp-mod-pressed';
 const TOOLBAR_BUSY = 'jp-mod-busy';
 
 /**
+ * The class name added to a cell in edit mode.
+ */
+const EDIT_CLASS = 'jp-mod-editMode';
+
+/**
+ * The class name added to a cell in command mode.
+ */
+const COMMAND_CLASS = 'jp-mod-commandMode';
+
+/**
  * The maximum size of the delete stack.
  */
 const DELETE_STACK_SIZE = 10;
@@ -167,8 +177,8 @@ class NotebookWidget extends Widget {
   /**
    * Create a new cell widget given a cell model.
    */
-  static createCell(cell: ICellModel): Widget {
-    let widget: Widget;
+  static createCell(cell: ICellModel): BaseCellWidget {
+    let widget: BaseCellWidget;
     switch(cell.type) {
     case 'code':
       widget = new CodeCellWidget(cell as CodeCellModel);
@@ -182,7 +192,7 @@ class NotebookWidget extends Widget {
     default:
       // If there are any issues, just return a blank placeholder
       // widget so the lists stay in sync.
-      widget = new Widget();
+      widget = new BaseCellWidget(cell);
     }
     widget.addClass(NB_CELL_CLASS);
     return widget;
@@ -222,6 +232,7 @@ class NotebookWidget extends Widget {
       cellsLayout.addChild(factory(model.cells.get(i)));
     }
     model.cells.changed.connect(this.onCellsChanged, this);
+    model.stateChanged.connect(this.onModelChanged, this);
   }
 
   /**
@@ -384,6 +395,56 @@ class NotebookWidget extends Widget {
   }
 
   /**
+   * Handle an `update-request` messages.
+   */
+  protected onUpdateRequest(msg: Message): void {
+    let model = this.model;
+    let current = model.cells.get(model.activeCellIndex);
+    if (!current) {
+      return;
+    }
+    let layout = this._notebook.layout as PanelLayout;
+    let widget = layout.childAt(model.activeCellIndex);
+    if (model.mode === 'command') {
+      widget.addClass(COMMAND_CLASS);
+      widget.removeClass(EDIT_CLASS);
+    } else {
+      widget.addClass(EDIT_CLASS);
+      widget.removeClass(COMMAND_CLASS);
+    }
+  }
+
+  /**
+   * Handle `after-attach` messages.
+   */
+  protected onAfterAttach(msg: Message): void {
+    this.update();
+  }
+
+  /**
+   * Handle changes to the notebook model.
+   */
+  protected onModelChanged(model: INotebookModel, args: IChangedArgs<any>): void {
+    switch (args.name) {
+     case 'activeCellIndex':
+     case 'mode':
+       this.update();
+       break;
+    }
+  }
+
+  /**
+   * Handle a change to the focused state of a cell's editor.
+   */
+  protected onEditorFocusChanged(cell: BaseCellWidget, value: boolean) {
+    if (value) {
+      this.model.mode = 'edit';
+    } else {
+      this.model.mode = 'command';
+    }
+  }
+
+  /**
    * Handle a change cells event.  This function must be on this class
    * because it uses the static [createCell] method.
    */
@@ -391,38 +452,41 @@ class NotebookWidget extends Widget {
     let layout = this._notebook.layout as PanelLayout;
     let constructor = this.constructor as typeof NotebookWidget;
     let factory = constructor.createCell;
-    let widget: Widget;
+    let widget: BaseCellWidget;
     switch(args.type) {
     case ListChangeType.Add:
-      widget = factory(args.newValue as ICellModel);
+      widget = factory(args.newValue as ICellModel) as BaseCellWidget;
+      widget.editorFocusChanged.connect(this.onEditorFocusChanged, this);
       layout.insertChild(args.newIndex, widget);
       break;
     case ListChangeType.Move:
       layout.insertChild(args.newIndex, layout.childAt(args.oldIndex));
       break;
     case ListChangeType.Remove:
-      widget = layout.childAt(args.oldIndex);
+      widget = layout.childAt(args.oldIndex) as BaseCellWidget;
       layout.removeChild(widget);
       widget.dispose();
       break;
     case ListChangeType.Replace:
       let oldValues = args.oldValue as ICellModel[];
       for (let i = args.oldIndex; i < oldValues.length; i++) {
-        widget = layout.childAt(args.oldIndex);
+        widget = layout.childAt(args.oldIndex) as BaseCellWidget;
         layout.removeChild(widget);
         widget.dispose();
       }
       let newValues = args.newValue as ICellModel[];
       for (let i = newValues.length; i < 0; i--) {
         widget = factory(newValues[i])
+        widget.editorFocusChanged.connect(this.onEditorFocusChanged, this);
         layout.insertChild(args.newIndex, widget);
       }
       break;
     case ListChangeType.Set:
-      widget = layout.childAt(args.newIndex);
+      widget = layout.childAt(args.newIndex) as BaseCellWidget;
       layout.removeChild(widget);
       widget.dispose();
       widget = factory(args.newValue as ICellModel);
+      widget.editorFocusChanged.connect(this.onEditorFocusChanged, this);
       layout.insertChild(args.newIndex, widget);
       break;
     }
@@ -577,7 +641,7 @@ class NotebookCells extends Widget {
     let cell = model.cells.get(i);
     if (isMarkdownCellModel(cell) && cell.rendered) {
       cell.rendered = false;
-      cell.mode = 'edit';
+      model.mode = 'edit';
     }
   }
 


### PR DESCRIPTION
Use focus/blur events and an explicit `focus()` method on the editor widget.
