### PR TITLE
Make executeCodeCell() return a Promise<void>

### DIFF
--- a/src/cells/model.ts
+++ b/src/cells/model.ts
@@ -526,7 +526,7 @@ class RawCellModel extends BaseCellModel implements IRawCellModel {
  * Execute the code cell using the given kernel.
  */
 export
-function executeCodeCell(cell: ICodeCellModel, kernel: IKernel): IKernelFuture {
+function executeCodeCell(cell: ICodeCellModel, kernel: IKernel): Promise<void> {
   let input = cell.input;
   let output = cell.output;
   let text = input.textEditor.text.trim();
@@ -535,7 +535,7 @@ function executeCodeCell(cell: ICodeCellModel, kernel: IKernel): IKernelFuture {
     return;
   }
   input.prompt = '*';
-  executeCode(text, kernel, output).then(reply => {
+  return executeCode(text, kernel, output).then(reply => {
     cell.executionCount = reply.execution_count;
   });
 }

--- a/test/src/cells/model.spec.ts
+++ b/test/src/cells/model.spec.ts
@@ -619,8 +619,8 @@ describe('jupyter-js-notebook', () => {
       let output = new OutputAreaModel();
       let model = new CodeCellModel(input, output);
       let kernel = new MockKernel();
-      model.input.prompt = '';
-      executeCodeCell(model, kernel);
+      model.input.prompt = '*';
+      executeCodeCell(model, kernel)
       expect(model.input.prompt).to.be('');
     });
 
@@ -631,7 +631,7 @@ describe('jupyter-js-notebook', () => {
       let model = new CodeCellModel(input, output);
       model.input.textEditor.text = 'a = 1';
       let kernel = new MockKernel();
-      executeCodeCell(model, kernel);
+      executeCodeCell(model, kernel)
       expect(model.input.prompt).to.be('*');
     });
 

--- a/test/src/cells/model.spec.ts
+++ b/test/src/cells/model.spec.ts
@@ -631,7 +631,7 @@ describe('jupyter-js-notebook', () => {
       let model = new CodeCellModel(input, output);
       model.input.textEditor.text = 'a = 1';
       let kernel = new MockKernel();
-      executeCodeCell(model, kernel)
+      executeCodeCell(model, kernel);
       expect(model.input.prompt).to.be('*');
     });
 

--- a/test/src/cells/model.spec.ts
+++ b/test/src/cells/model.spec.ts
@@ -619,8 +619,8 @@ describe('jupyter-js-notebook', () => {
       let output = new OutputAreaModel();
       let model = new CodeCellModel(input, output);
       let kernel = new MockKernel();
-      model.input.prompt = '*';
-      executeCodeCell(model, kernel)
+      model.input.prompt = null;
+      executeCodeCell(model, kernel);
       expect(model.input.prompt).to.be('');
     });
 


### PR DESCRIPTION
Because the console waits until execution is finished before creating a new prompt, `executeCodeCell()` needs to return a `Promise`.
