### PR TITLE
Completion tweak

### DIFF
--- a/src/cells/editor.ts
+++ b/src/cells/editor.ts
@@ -204,7 +204,7 @@ class CellEditorWidget extends CodeMirrorWidget {
     case 'source':
       let doc = this.editor.getDoc();
       if (doc.getValue() !== args.newValue) {
-        doc.setValue(this._model.source);
+        doc.setValue(args.newValue);
       }
       break;
     default:

--- a/src/cells/editor.ts
+++ b/src/cells/editor.ts
@@ -22,10 +22,6 @@ import {
 } from 'phosphor-signaling';
 
 import {
-  Widget
-} from 'phosphor-widget';
-
-import {
   ICellModel
 } from './model';
 

--- a/src/cells/editor.ts
+++ b/src/cells/editor.ts
@@ -22,6 +22,10 @@ import {
 } from 'phosphor-signaling';
 
 import {
+  Widget
+} from 'phosphor-widget';
+
+import {
   ICellModel
 } from './model';
 
@@ -128,13 +132,15 @@ class CellEditorWidget extends CodeMirrorWidget {
     this._model = model;
     let editor = this.editor;
     let doc = editor.getDoc();
+    if (model.source) {
+      doc.setValue(model.source);
+    }
     CodeMirror.on(doc, 'change', (instance, change) => {
       this.onDocChange(instance, change);
     });
     CodeMirror.on(editor, 'keydown', (instance, evt) => {
       this.onEditorKeydown(instance, evt);
     });
-    this.update();
     model.stateChanged.connect(this.onModelChanged, this);
   }
 
@@ -187,14 +193,11 @@ class CellEditorWidget extends CodeMirrorWidget {
   }
 
   /**
-   * Handle an `update-request` message.
+   * Set the current cursor position of the editor.
    */
-  protected onUpdateRequest(msg: Message): void {
+  setCursorPosition(position: number): void {
     let doc = this.editor.getDoc();
-    let value = doc.getValue();
-    if (value !== this._model.source) {
-      doc.setValue(this._model.source);
-    }
+    doc.setCursor(doc.posFromIndex(position));
   }
 
   /**
@@ -203,7 +206,10 @@ class CellEditorWidget extends CodeMirrorWidget {
   protected onModelChanged(model: ICellModel, args: IChangedArgs<any>): void {
     switch (args.name) {
     case 'source':
-      this.update();
+      let doc = this.editor.getDoc();
+      if (doc.getValue() !== args.newValue) {
+        doc.setValue(this._model.source);
+      }
       break;
     default:
       break;

--- a/src/console/widget.ts
+++ b/src/console/widget.ts
@@ -566,13 +566,8 @@ class ConsoleWidget extends Widget {
   protected onCompletionSelect(widget: CompletionWidget, value: string): void {
     let prompt = this.prompt;
     let patch = this._completion.model.createPatch(value);
-    let doc = prompt.editor.editor.getDoc();
-    // Update the prompt model.
     prompt.model.source = patch.text;
-    // Because the prompt model triggers a DOM update asynchronously,
-    // CodeMirror value and position need to be set manually (synchronously).
-    doc.setValue(patch.text);
-    doc.setCursor(doc.posFromIndex(patch.position));
+    prompt.editor.setCursorPosition(patch.position);
   }
 
   private _completion: CompletionWidget = null;


### PR DESCRIPTION
After talking with @sccolbert, this PR changes the way that the editor widget's text and cursor position are updated, relying on CodeMirror's internal operation queue to guarantee things happen in the correct order.

As a result, there is no longer a need for an `onUpdateRequest`.

cc @blink1073 @jasongrout, you might both be curious about this.
